### PR TITLE
Initial architecture for gîtes arrivals viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# What Today ?
+
+Application web élégante affichant les arrivées à venir dans plusieurs gîtes.
+Le projet est composé d'un backend Node.js chargé de parser des fichiers
+`ics` et d'un frontend React (Material‑UI) qui présente les informations
+sous forme d'une liste et d'un petit calendrier coloré.
+
+## Fonctionnalités
+- Chargement des calendriers iCal (Airbnb, Abritel, etc.) au démarrage du serveur.
+- Gestion du cas particulier `Airbnb (Not available)` transformé en "Réservation en direct".
+- Endpoint JSON `/api/arrivals` exposant les arrivées des 7 prochains jours.
+- Interface React Material‑UI : mot de passe à la première connexion (stocké en
+  `localStorage`), loader animé, calendrier 7 jours en ligne avec pastilles
+  colorées et icônes selon la plateforme, liste détaillée des arrivées.
+- Formatage des dates en français.
+- Affichage d'un `?` lorsqu'une source iCal est inaccessible.
+
+## Pré‑requis
+- Node.js ≥ 18
+- npm
+
+## Installation
+```bash
+# Backend
+cd backend
+npm install
+
+# Frontend
+cd ../frontend
+npm install
+```
+
+## Utilisation
+### Lancer le serveur API
+```bash
+cd backend
+npm start
+```
+Le serveur écoute par défaut sur le port **3001** et charge les fichiers `ics`
+une seule fois au démarrage.
+
+### Lancer le frontend
+Ce dépôt fournit uniquement le code source React. Utilisez le bundler de votre
+choix (Vite, Create React App, etc.). Exemple avec Vite :
+```bash
+npm create vite@latest frontend -- --template react
+```
+Copiez ensuite le contenu du dossier `frontend/src` dans votre application
+Vite et ajoutez les dépendances indiquées dans `frontend/package.json`.
+
+Définissez le mot de passe attendu côté frontend via une variable
+d'environnement `REACT_APP_PASSWORD` (par défaut : `secret`).
+
+## Tests
+Aucun test automatisé n'est encore défini. Les commandes `npm test` dans les
+sous‑projets affichent simplement un message.
+
+## Architecture
+```
+what-today/
+├── backend/            # Serveur Node.js (Express)
+│   ├── server.js       # Chargement des ics et endpoint JSON
+│   └── package.json
+├── frontend/           # Interface React + Material‑UI
+│   ├── src/
+│   │   ├── components/ # Login, calendrier, liste, loader
+│   │   ├── services/   # Accès API
+│   │   ├── App.js
+│   │   └── index.js
+│   └── package.json
+└── README.md
+```
+
+## Sécurité
+Un écran de mot de passe est affiché lors de la première visite. Une fois le
+mot de passe correct saisi, l'information est mémorisée en `localStorage` et
+les visites suivantes accèdent directement à l'application.
+
+## Licence
+Projet destiné à démonstration. Utilisation à vos risques.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "what-today-backend",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo 'No tests'"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "node-fetch": "^3.3.2",
+    "node-ical": "^0.15.0",
+    "dayjs": "^1.11.10"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,132 @@
+import express from 'express';
+import cors from 'cors';
+import fetch from 'node-fetch';
+import ical from 'node-ical';
+import dayjs from 'dayjs';
+import 'dayjs/locale/fr.js';
+
+// Configuration locale française pour dayjs
+// permet d'avoir des dates formatées "lundi 31/12/2025"
+dayjs.locale('fr');
+
+const app = express();
+app.use(cors());
+
+// --- Définition des gîtes et de leurs sources ical ---
+// Chaque gîte possède plusieurs URLs ical, correspondant à
+// différentes plateformes de réservation.
+const GITES = [
+  {
+    id: 'phonsine',
+    nom: 'Gîte de Phonsine',
+    couleur: '#E53935', // rouge
+    sources: [
+      { url: 'https://www.airbnb.fr/calendar/ical/6668903.ics?s=3610ebea31b864e7d5091b80938c221e', type: 'Airbnb' },
+      { url: 'http://www.abritel.fr/icalendar/ddd9339eb15b46a6acc3f1f24f2b0f50.ics?nonTentative', type: 'Abritel' }
+    ]
+  },
+  {
+    id: 'liberte',
+    nom: 'Gîte Le Liberté',
+    couleur: '#8E24AA', // violet
+    sources: [
+      { url: 'https://www.airbnb.fr/calendar/ical/1182344118629001592.ics?s=641548df33ebc6bf6b5f383c7aec25ac', type: 'Airbnb' },
+      { url: 'https://www.airbnb.fr/calendar/ical/48504640.ics?s=c27d399e029a03b6b4dd791fbf026fee', type: 'Airbnb' },
+      { url: 'http://www.abritel.fr/icalendar/094a7b5f6cf345f9b51940e07e588ab2.ics', type: 'Abritel' }
+    ]
+  },
+  {
+    id: 'gree',
+    nom: 'Gîte de la Grée',
+    couleur: '#3949AB', // bleu
+    sources: [
+      { url: 'http://www.abritel.fr/icalendar/3d33e48aeded478f8c11deda36f20008.ics?nonTentative', type: 'Abritel' },
+      { url: 'https://www.airbnb.fr/calendar/ical/16674752.ics?s=54a0101efa1112c86756ed2184506173', type: 'Airbnb' },
+      { url: 'https://www.airbnb.fr/calendar/ical/1256595615494549883.ics?s=61ea920c4f6392380d88563f08adcfee', type: 'Airbnb' }
+    ]
+  },
+  {
+    id: 'edmond',
+    nom: "Gîte de l'oncle Edmond",
+    couleur: '#43A047', // vert
+    sources: [
+      { url: 'https://www.airbnb.fr/calendar/ical/43504621.ics?s=ff78829f694b64d20d1c56c81b319d1f', type: 'Airbnb' }
+    ]
+  }
+];
+
+// Stockage en mémoire des réservations et des erreurs
+let reservations = [];
+let erreurs = new Set();
+
+/**
+ * Chargement et parsing de toutes les sources ical.
+ * Cette fonction est exécutée une seule fois au démarrage du serveur.
+ */
+async function chargerCalendriers() {
+  for (const gite of GITES) {
+    for (const source of gite.sources) {
+      try {
+        const res = await fetch(source.url);
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const text = await res.text();
+
+        // Parsing du contenu ical
+        const data = ical.parseICS(text);
+        for (const ev of Object.values(data)) {
+          if (ev.type === 'VEVENT') {
+            let typeSource = source.type;
+            // Si le summary contient "Airbnb (Not available)"
+            // alors on considère la réservation comme directe
+            if (
+              typeSource === 'Airbnb' &&
+              typeof ev.summary === 'string' &&
+              ev.summary.includes('Airbnb (Not available)')
+            ) {
+              typeSource = 'Direct';
+            }
+
+            reservations.push({
+              giteId: gite.id,
+              giteNom: gite.nom,
+              couleur: gite.couleur,
+              source: typeSource,
+              debut: ev.start, // Date d'arrivée
+              fin: ev.end,
+              resume: ev.summary || ''
+            });
+          }
+        }
+      } catch (err) {
+        // En cas d'erreur, on stocke l'identifiant du gîte
+        erreurs.add(gite.id);
+        console.error('Erreur de chargement pour', gite.nom, err.message);
+      }
+    }
+  }
+
+  // Filtrage sur les 7 prochains jours
+  const aujourdHui = dayjs().startOf('day');
+  const limite = aujourdHui.add(7, 'day');
+  reservations = reservations.filter(ev =>
+    dayjs(ev.debut).isAfter(aujourdHui.subtract(1, 'day')) &&
+    dayjs(ev.debut).isBefore(limite)
+  );
+}
+
+// Chargement des calendriers au démarrage
+await chargerCalendriers();
+
+// --- Endpoint JSON ---
+app.get('/api/arrivals', (req, res) => {
+  res.json({
+    genereLe: new Date().toISOString(),
+    reservations,
+    erreurs: Array.from(erreurs)
+  });
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log('Serveur démarré sur le port', PORT);
+});

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Mot de passe attendu côté frontend
+REACT_APP_PASSWORD=secret

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "what-today-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "echo 'Lancez votre bundler préféré (ex: Vite)'",
+    "test": "echo 'No tests'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@mui/material": "^5.14.7",
+    "@mui/icons-material": "^5.14.7",
+    "dayjs": "^1.11.10"
+  }
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import Login from './components/Login';
+import CalendarBar from './components/CalendarBar';
+import ArrivalsList from './components/ArrivalsList';
+import Loader from './components/Loader';
+import { fetchArrivals } from './services/api';
+
+// Clé utilisée pour mémoriser l'authentification en localStorage
+const AUTH_KEY = 'wt-authenticated';
+
+function App() {
+  const [auth, setAuth] = useState(localStorage.getItem(AUTH_KEY) === 'true');
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState({ reservations: [], erreurs: [] });
+
+  // Chargement des données après authentification
+  useEffect(() => {
+    if (!auth) return;
+    fetchArrivals()
+      .then(setData)
+      .finally(() => setLoading(false));
+  }, [auth]);
+
+  // Fonction de validation du mot de passe
+  const handleLogin = password => {
+    const expected = process.env.REACT_APP_PASSWORD || 'secret';
+    if (password === expected) {
+      localStorage.setItem(AUTH_KEY, 'true');
+      setAuth(true);
+    }
+  };
+
+  if (!auth) return <Login onLogin={handleLogin} />;
+  if (loading) return <Loader />;
+
+  return (
+    <div>
+      <CalendarBar bookings={data.reservations} errors={data.erreurs} />
+      <ArrivalsList bookings={data.reservations} errors={data.erreurs} />
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/components/ArrivalsList.js
+++ b/frontend/src/components/ArrivalsList.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Box, Typography, List, ListItem, ListItemAvatar, Avatar, ListItemText } from '@mui/material';
+import dayjs from 'dayjs';
+import { Home, BeachAccess, Nature, Phone } from '@mui/icons-material';
+
+// Même mapping d'icônes que dans CalendarBar
+function sourceIcon(type) {
+  switch (type) {
+    case 'Airbnb':
+      return <Home />;
+    case 'Abritel':
+      return <BeachAccess />;
+    case 'GitesDeFrance':
+      return <Nature />;
+    case 'Direct':
+    default:
+      return <Phone />;
+  }
+}
+
+/**
+ * Liste des arrivées à venir (aujourd'hui + 6 jours).
+ * Aujourd'hui et demain sont mis en avant.
+ */
+function ArrivalsList({ bookings, errors }) {
+  const today = dayjs().startOf('day');
+  const tomorrow = today.add(1, 'day');
+
+  const format = d => d.format('dddd DD/MM');
+
+  const groupes = {
+    today: bookings.filter(b => dayjs(b.debut).isSame(today, 'day')),
+    tomorrow: bookings.filter(b => dayjs(b.debut).isSame(tomorrow, 'day')),
+    next: bookings.filter(b =>
+      dayjs(b.debut).isAfter(tomorrow, 'day')
+    )
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      {['today', 'tomorrow'].map(key => (
+        <Box key={key} sx={{ mb: 2 }}>
+          <Typography variant="h6">
+            {key === 'today' ? 'Aujourd\'hui' : 'Demain'}
+          </Typography>
+          <List>
+            {groupes[key].map((ev, idx) => (
+              <ListItem key={idx} sx={{ bgcolor: ev.couleur + '33', mb: 1 }}>
+                <ListItemAvatar>
+                  <Avatar sx={{ bgcolor: ev.couleur }}>{sourceIcon(ev.source)}</Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary={ev.giteNom}
+                  secondary={format(dayjs(ev.debut))}
+                />
+              </ListItem>
+            ))}
+            {groupes[key].length === 0 && (
+              <Typography variant="body2" sx={{ ml: 2 }}>
+                Aucune arrivée
+              </Typography>
+            )}
+          </List>
+        </Box>
+      ))}
+
+      <Typography variant="h6">Prochains jours</Typography>
+      <List>
+        {groupes.next.map((ev, idx) => (
+          <ListItem key={idx}>
+            <ListItemAvatar>
+              <Avatar sx={{ bgcolor: ev.couleur }}>{sourceIcon(ev.source)}</Avatar>
+            </ListItemAvatar>
+            <ListItemText
+              primary={`${format(dayjs(ev.debut))} - ${ev.giteNom}`}
+            />
+          </ListItem>
+        ))}
+        {groupes.next.length === 0 && (
+          <Typography variant="body2" sx={{ ml: 2 }}>
+            Rien à signaler
+          </Typography>
+        )}
+      </List>
+
+      {errors.length > 0 && (
+        <Typography color="error" sx={{ mt: 2 }}>
+          ? Données manquantes pour : {errors.join(', ')}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+export default ArrivalsList;

--- a/frontend/src/components/CalendarBar.js
+++ b/frontend/src/components/CalendarBar.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Box, Typography, Tooltip, Avatar } from '@mui/material';
+import { Home, BeachAccess, Nature, Phone } from '@mui/icons-material';
+import { keyframes } from '@mui/system';
+import dayjs from 'dayjs';
+
+// Animation légère pour les arrivées du jour
+const pulse = keyframes`
+  0% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+  100% { transform: scale(1); }
+`;
+
+// Renvoie l'icône correspondant à la source de réservation
+function sourceIcon(type) {
+  switch (type) {
+    case 'Airbnb':
+      return <Home fontSize="inherit" />;
+    case 'Abritel':
+      return <BeachAccess fontSize="inherit" />;
+    case 'GitesDeFrance':
+      return <Nature fontSize="inherit" />;
+    case 'Direct':
+    default:
+      return <Phone fontSize="inherit" />;
+  }
+}
+
+/**
+ * Barre de calendrier sur 7 jours.
+ * Les réservations sont représentées par des pastilles colorées
+ * (une couleur par gîte). Tooltip au survol pour voir le détail.
+ */
+function CalendarBar({ bookings, errors }) {
+  // Construction de la structure { date -> [events] }
+  const days = Array.from({ length: 7 }).map((_, i) => {
+    const date = dayjs().startOf('day').add(i, 'day');
+    return {
+      date,
+      events: bookings.filter(b => dayjs(b.debut).isSame(date, 'day'))
+    };
+  });
+
+  return (
+    <Box sx={{ display: 'flex', overflowX: 'auto', p: 1 }}>
+      {days.map(({ date, events }) => (
+        <Box key={date.format('YYYY-MM-DD')} sx={{ textAlign: 'center', flex: 1 }}>
+          <Typography variant="caption">
+            {date.format('dd DD/MM')}
+          </Typography>
+          <Box sx={{ display: 'flex', justifyContent: 'center', gap: 0.5, mt: 0.5 }}>
+            {events.slice(0, 3).map((ev, idx) => (
+              <Tooltip
+                key={idx}
+                title={`${ev.giteNom} - ${ev.source}`}
+                arrow
+              >
+                <Avatar
+                  sx={{
+                    bgcolor: ev.couleur,
+                    width: 24,
+                    height: 24,
+                    fontSize: 16,
+                    animation: dayjs(ev.debut).isSame(dayjs(), 'day') ? `${pulse} 2s infinite` : 'none'
+                  }}
+                >
+                  {sourceIcon(ev.source)}
+                </Avatar>
+              </Tooltip>
+            ))}
+            {events.length > 3 && (
+              <Avatar sx={{ width: 24, height: 24, fontSize: 12 }}>
+                +{events.length - 3}
+              </Avatar>
+            )}
+          </Box>
+        </Box>
+      ))}
+      {errors.length > 0 && (
+        <Box sx={{ ml: 2 }}>
+          <Tooltip title={`Sources indisponibles: ${errors.join(', ')}`}>
+            <Typography variant="h6">?</Typography>
+          </Tooltip>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export default CalendarBar;

--- a/frontend/src/components/Loader.js
+++ b/frontend/src/components/Loader.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Box, CircularProgress, Typography } from '@mui/material';
+
+/** Loader central élégant affiché durant la récupération des données */
+function Loader() {
+  return (
+    <Box
+      sx={{
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: 2
+      }}
+    >
+      <CircularProgress color="secondary" />
+      <Typography>Chargement des réservations...</Typography>
+    </Box>
+  );
+}
+
+export default Loader;

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { Box, TextField, Button, Typography } from '@mui/material';
+
+/**
+ * Écran de demande de mot de passe (affiché uniquement lors
+ * de la première visite). Le mot de passe attendu est fourni
+ * par la prop `onLogin`.
+ */
+function Login({ onLogin }) {
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    onLogin(password);
+  };
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: 2
+      }}
+    >
+      <Typography variant="h5">Accès réservé</Typography>
+      <TextField
+        type="password"
+        label="Mot de passe"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      <Button variant="contained" type="submit">
+        Entrer
+      </Button>
+    </Box>
+  );
+}
+
+export default Login;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import dayjs from 'dayjs';
+import 'dayjs/locale/fr';
+
+// Application configurée en français
+// (formats de date, noms des jours...)
+dayjs.locale('fr');
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,6 @@
+// Appels au backend pour récupérer les arrivées
+export async function fetchArrivals() {
+  const res = await fetch('/api/arrivals');
+  if (!res.ok) throw new Error('HTTP ' + res.status);
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- setup Express backend to load remote ICS calendars, normalize Airbnb "Not available" entries, and expose `/api/arrivals`
- create React/Material‑UI frontend with password gate, 7‑day calendar bar, arrival list, and loader
- document installation and usage in French README

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68911314677c83228fcc6cc5046ae60a