### PR TITLE
feat(frontend): add mui theme provider

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "what-today-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^5.18.0",
         "@mui/material": "^5.14.7",
         "dayjs": "^1.11.13",
@@ -76,6 +78,14 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
       "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.0",
       "license": "MIT"
     },
     "node_modules/@emotion/weak-memoize": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
     "test": "react-scripts test"
   },
   "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^5.18.0",
     "@mui/material": "^5.14.7",
     "dayjs": "^1.11.13",

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,10 +3,18 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import dayjs from 'dayjs';
 import 'dayjs/locale/fr';
+import { ThemeProvider, CssBaseline, createTheme } from '@mui/material';
 
 // Application configurée en français
 // (formats de date, noms des jours...)
 dayjs.locale('fr');
 
+const theme = createTheme();
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+root.render(
+  <ThemeProvider theme={theme}>
+    <CssBaseline />
+    <App />
+  </ThemeProvider>
+);


### PR DESCRIPTION
## Summary
- add @emotion packages for MUI
- initialize MUI ThemeProvider with default theme

## Testing
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891c9e98bd48322a110d0ab6b0f42a4