### PR TITLE
feat(frontend): style sections with cards and logos

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import CalendarBar from './components/CalendarBar';
 import ArrivalsList from './components/ArrivalsList';
 import Loader from './components/Loader';
 import { fetchArrivals } from './services/api';
+import { Box } from '@mui/material';
 
 // Clé utilisée pour mémoriser l'authentification en localStorage
 const AUTH_KEY = 'wt-authenticated';
@@ -34,10 +35,10 @@ function App() {
   if (loading) return <Loader />;
 
   return (
-    <div>
+    <Box sx={{ maxWidth: 800, mx: 'auto', width: '100%' }}>
       <CalendarBar bookings={data.reservations} errors={data.erreurs} />
       <ArrivalsList bookings={data.reservations} errors={data.erreurs} />
-    </div>
+    </Box>
   );
 }
 

--- a/frontend/src/assets/logos/abritel.svg
+++ b/frontend/src/assets/logos/abritel.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" ry="4" fill="#008489"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">AB</text>
+</svg>

--- a/frontend/src/assets/logos/airbnb.svg
+++ b/frontend/src/assets/logos/airbnb.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="10" fill="#FF5A5F"/>
+  <text x="12" y="16" font-size="12" text-anchor="middle" fill="#fff">A</text>
+</svg>

--- a/frontend/src/assets/logos/gitesdefrance.svg
+++ b/frontend/src/assets/logos/gitesdefrance.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="10" fill="#4CAF50"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">GF</text>
+</svg>

--- a/frontend/src/components/ArrivalsList.js
+++ b/frontend/src/components/ArrivalsList.js
@@ -1,20 +1,22 @@
 import React from 'react';
-import { Box, Typography, List, ListItem, ListItemAvatar, Avatar, ListItemText } from '@mui/material';
+import { Box, Typography, List, ListItem, ListItemAvatar, Avatar, ListItemText, Card, CardContent } from '@mui/material';
 import dayjs from 'dayjs';
-import { Home, BeachAccess, Nature, Phone } from '@mui/icons-material';
+import { Phone } from '@mui/icons-material';
+import airbnbLogo from '../assets/logos/airbnb.svg';
+import abritelLogo from '../assets/logos/abritel.svg';
+import gdfLogo from '../assets/logos/gitesdefrance.svg';
 
-// Même mapping d'icônes que dans CalendarBar
-function sourceIcon(type) {
+// Renvoie le logo correspondant à la source ou null si non disponible
+function sourceLogo(type) {
   switch (type) {
     case 'Airbnb':
-      return <Home />;
+      return airbnbLogo;
     case 'Abritel':
-      return <BeachAccess />;
+      return abritelLogo;
     case 'GitesDeFrance':
-      return <Nature />;
-    case 'Direct':
+      return gdfLogo;
     default:
-      return <Phone />;
+      return null;
   }
 }
 
@@ -39,49 +41,81 @@ function ArrivalsList({ bookings, errors }) {
   return (
     <Box sx={{ p: 2 }}>
       {['today', 'tomorrow'].map(key => (
-        <Box key={key} sx={{ mb: 2 }}>
-          <Typography variant="h6">
-            {key === 'today' ? 'Aujourd\'hui' : 'Demain'}
-          </Typography>
+        <Card key={key} sx={{ mb: 2, boxShadow: 3 }}>
+          <CardContent>
+            <Typography variant="h6">
+              {key === 'today' ? 'Aujourd\'hui' : 'Demain'}
+            </Typography>
+            <List>
+              {groupes[key].map((ev, idx) => {
+                const logo = sourceLogo(ev.source);
+                return (
+                  <ListItem key={idx} sx={{ bgcolor: ev.couleur + '33', mb: 1 }}>
+                    <ListItemAvatar>
+                      <Avatar
+                        src={logo || undefined}
+                        sx={{
+                          bgcolor: logo ? '#fff' : ev.couleur,
+                          boxShadow: 1,
+                          transition: 'transform 0.2s',
+                          '&:hover': { transform: 'scale(1.05)' }
+                        }}
+                      >
+                        {!logo && <Phone />}
+                      </Avatar>
+                    </ListItemAvatar>
+                    <ListItemText
+                      primary={ev.giteNom}
+                      secondary={format(dayjs(ev.debut))}
+                    />
+                  </ListItem>
+                );
+              })}
+              {groupes[key].length === 0 && (
+                <Typography variant="body2" sx={{ ml: 2 }}>
+                  Aucune arrivée
+                </Typography>
+              )}
+            </List>
+          </CardContent>
+        </Card>
+      ))}
+
+      <Card sx={{ mb: 2, boxShadow: 3 }}>
+        <CardContent>
+          <Typography variant="h6">Prochains jours</Typography>
           <List>
-            {groupes[key].map((ev, idx) => (
-              <ListItem key={idx} sx={{ bgcolor: ev.couleur + '33', mb: 1 }}>
-                <ListItemAvatar>
-                  <Avatar sx={{ bgcolor: ev.couleur }}>{sourceIcon(ev.source)}</Avatar>
-                </ListItemAvatar>
-                <ListItemText
-                  primary={ev.giteNom}
-                  secondary={format(dayjs(ev.debut))}
-                />
-              </ListItem>
-            ))}
-            {groupes[key].length === 0 && (
+            {groupes.next.map((ev, idx) => {
+              const logo = sourceLogo(ev.source);
+              return (
+                <ListItem key={idx}>
+                  <ListItemAvatar>
+                    <Avatar
+                      src={logo || undefined}
+                      sx={{
+                        bgcolor: logo ? '#fff' : ev.couleur,
+                        boxShadow: 1,
+                        transition: 'transform 0.2s',
+                        '&:hover': { transform: 'scale(1.05)' }
+                      }}
+                    >
+                      {!logo && <Phone />}
+                    </Avatar>
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary={`${format(dayjs(ev.debut))} - ${ev.giteNom}`}
+                  />
+                </ListItem>
+              );
+            })}
+            {groupes.next.length === 0 && (
               <Typography variant="body2" sx={{ ml: 2 }}>
-                Aucune arrivée
+                Rien à signaler
               </Typography>
             )}
           </List>
-        </Box>
-      ))}
-
-      <Typography variant="h6">Prochains jours</Typography>
-      <List>
-        {groupes.next.map((ev, idx) => (
-          <ListItem key={idx}>
-            <ListItemAvatar>
-              <Avatar sx={{ bgcolor: ev.couleur }}>{sourceIcon(ev.source)}</Avatar>
-            </ListItemAvatar>
-            <ListItemText
-              primary={`${format(dayjs(ev.debut))} - ${ev.giteNom}`}
-            />
-          </ListItem>
-        ))}
-        {groupes.next.length === 0 && (
-          <Typography variant="body2" sx={{ ml: 2 }}>
-            Rien à signaler
-          </Typography>
-        )}
-      </List>
+        </CardContent>
+      </Card>
 
       {errors.length > 0 && (
         <Typography color="error" sx={{ mt: 2 }}>

--- a/frontend/src/components/CalendarBar.js
+++ b/frontend/src/components/CalendarBar.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import { Box, Typography, Tooltip, Avatar } from '@mui/material';
-import { Home, BeachAccess, Nature, Phone } from '@mui/icons-material';
+import { Box, Typography, Tooltip, Avatar, Card, CardContent } from '@mui/material';
+import { Phone } from '@mui/icons-material';
 import { keyframes } from '@mui/system';
 import dayjs from 'dayjs';
+import airbnbLogo from '../assets/logos/airbnb.svg';
+import abritelLogo from '../assets/logos/abritel.svg';
+import gdfLogo from '../assets/logos/gitesdefrance.svg';
 
 // Animation légère pour les arrivées du jour
 const pulse = keyframes`
@@ -11,18 +14,17 @@ const pulse = keyframes`
   100% { transform: scale(1); }
 `;
 
-// Renvoie l'icône correspondant à la source de réservation
-function sourceIcon(type) {
+// Renvoie le logo correspondant à la source ou null si non disponible
+function sourceLogo(type) {
   switch (type) {
     case 'Airbnb':
-      return <Home fontSize="inherit" />;
+      return airbnbLogo;
     case 'Abritel':
-      return <BeachAccess fontSize="inherit" />;
+      return abritelLogo;
     case 'GitesDeFrance':
-      return <Nature fontSize="inherit" />;
-    case 'Direct':
+      return gdfLogo;
     default:
-      return <Phone fontSize="inherit" />;
+      return null;
   }
 }
 
@@ -42,48 +44,59 @@ function CalendarBar({ bookings, errors }) {
   });
 
   return (
-    <Box sx={{ display: 'flex', overflowX: 'auto', p: 1 }}>
-      {days.map(({ date, events }) => (
-        <Box key={date.format('YYYY-MM-DD')} sx={{ textAlign: 'center', flex: 1 }}>
-          <Typography variant="caption">
-            {date.format('dd DD/MM')}
-          </Typography>
-          <Box sx={{ display: 'flex', justifyContent: 'center', gap: 0.5, mt: 0.5 }}>
-            {events.slice(0, 3).map((ev, idx) => (
-              <Tooltip
-                key={idx}
-                title={`${ev.giteNom} - ${ev.source}`}
-                arrow
-              >
-                <Avatar
-                  sx={{
-                    bgcolor: ev.couleur,
-                    width: 24,
-                    height: 24,
-                    fontSize: 16,
-                    animation: dayjs(ev.debut).isSame(dayjs(), 'day') ? `${pulse} 2s infinite` : 'none'
-                  }}
-                >
-                  {sourceIcon(ev.source)}
-                </Avatar>
+    <Card sx={{ mb: 2, boxShadow: 3 }}>
+      <CardContent sx={{ p: 1 }}>
+        <Box sx={{ display: 'flex', overflowX: 'auto' }}>
+          {days.map(({ date, events }) => (
+            <Box key={date.format('YYYY-MM-DD')} sx={{ textAlign: 'center', flex: 1 }}>
+              <Typography variant="caption">
+                {date.format('dd DD/MM')}
+              </Typography>
+              <Box sx={{ display: 'flex', justifyContent: 'center', gap: 0.5, mt: 0.5 }}>
+                {events.slice(0, 3).map((ev, idx) => {
+                  const logo = sourceLogo(ev.source);
+                  return (
+                    <Tooltip
+                      key={idx}
+                      title={`${ev.giteNom} - ${ev.source}`}
+                      arrow
+                    >
+                      <Avatar
+                        src={logo || undefined}
+                        sx={{
+                          bgcolor: logo ? '#fff' : ev.couleur,
+                          width: 24,
+                          height: 24,
+                          fontSize: 16,
+                          boxShadow: 2,
+                          transition: 'transform 0.2s',
+                          '&:hover': { transform: 'scale(1.1)' },
+                          animation: dayjs(ev.debut).isSame(dayjs(), 'day') ? `${pulse} 2s infinite` : 'none'
+                        }}
+                      >
+                        {!logo && <Phone fontSize="inherit" />}
+                      </Avatar>
+                    </Tooltip>
+                  );
+                })}
+                {events.length > 3 && (
+                  <Avatar sx={{ width: 24, height: 24, fontSize: 12 }}>
+                    +{events.length - 3}
+                  </Avatar>
+                )}
+              </Box>
+            </Box>
+          ))}
+          {errors.length > 0 && (
+            <Box sx={{ ml: 2 }}>
+              <Tooltip title={`Sources indisponibles: ${errors.join(', ')}`}>
+                <Typography variant="h6">?</Typography>
               </Tooltip>
-            ))}
-            {events.length > 3 && (
-              <Avatar sx={{ width: 24, height: 24, fontSize: 12 }}>
-                +{events.length - 3}
-              </Avatar>
-            )}
-          </Box>
+            </Box>
+          )}
         </Box>
-      ))}
-      {errors.length > 0 && (
-        <Box sx={{ ml: 2 }}>
-          <Tooltip title={`Sources indisponibles: ${errors.join(', ')}`}>
-            <Typography variant="h6">?</Typography>
-          </Tooltip>
-        </Box>
-      )}
-    </Box>
+      </CardContent>
+    </Card>
   );
 }
 


### PR DESCRIPTION
## Summary
- Wrap calendar and arrivals sections in MUI cards with shadows and hover effects
- Limit desktop layout width to 800px
- Add placeholder SVG logos for Airbnb, Abritel and Gîtes de France

## Testing
- `npm test --silent` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891dc9a75bc8322a8276a9202213d49