### PR TITLE
feat: add calendar legend for colors and logos

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import ArrivalsList from './components/ArrivalsList';
 import Loader from './components/Loader';
 import { fetchArrivals } from './services/api';
 import { Box } from '@mui/material';
+import Legend from './components/Legend';
 
 // Clé utilisée pour mémoriser l'authentification en localStorage
 const AUTH_KEY = 'wt-authenticated';
@@ -37,6 +38,7 @@ function App() {
   return (
     <Box sx={{ maxWidth: 800, mx: 'auto', width: '100%' }}>
       <CalendarBar bookings={data.reservations} errors={data.erreurs} />
+      <Legend bookings={data.reservations} />
       <ArrivalsList bookings={data.reservations} errors={data.erreurs} />
     </Box>
   );

--- a/frontend/src/components/ArrivalsList.js
+++ b/frontend/src/components/ArrivalsList.js
@@ -2,23 +2,7 @@ import React from 'react';
 import { Box, Typography, List, ListItem, ListItemAvatar, Avatar, ListItemText, Card, CardContent } from '@mui/material';
 import dayjs from 'dayjs';
 import { Phone } from '@mui/icons-material';
-import airbnbLogo from '../assets/logos/airbnb.svg';
-import abritelLogo from '../assets/logos/abritel.svg';
-import gdfLogo from '../assets/logos/gitesdefrance.svg';
-
-// Renvoie le logo correspondant à la source ou null si non disponible
-function sourceLogo(type) {
-  switch (type) {
-    case 'Airbnb':
-      return airbnbLogo;
-    case 'Abritel':
-      return abritelLogo;
-    case 'GitesDeFrance':
-      return gdfLogo;
-    default:
-      return null;
-  }
-}
+import { sourceLogo } from '../utils';
 
 /**
  * Liste des arrivées à venir (aujourd'hui + 6 jours).

--- a/frontend/src/components/CalendarBar.js
+++ b/frontend/src/components/CalendarBar.js
@@ -3,9 +3,7 @@ import { Box, Typography, Tooltip, Avatar, Card, CardContent } from '@mui/materi
 import { Phone } from '@mui/icons-material';
 import { keyframes } from '@mui/system';
 import dayjs from 'dayjs';
-import airbnbLogo from '../assets/logos/airbnb.svg';
-import abritelLogo from '../assets/logos/abritel.svg';
-import gdfLogo from '../assets/logos/gitesdefrance.svg';
+import { sourceLogo } from '../utils';
 
 // Animation légère pour les arrivées du jour
 const pulse = keyframes`
@@ -13,20 +11,6 @@ const pulse = keyframes`
   50% { transform: scale(1.3); }
   100% { transform: scale(1); }
 `;
-
-// Renvoie le logo correspondant à la source ou null si non disponible
-function sourceLogo(type) {
-  switch (type) {
-    case 'Airbnb':
-      return airbnbLogo;
-    case 'Abritel':
-      return abritelLogo;
-    case 'GitesDeFrance':
-      return gdfLogo;
-    default:
-      return null;
-  }
-}
 
 /**
  * Barre de calendrier sur 7 jours.

--- a/frontend/src/components/Legend.js
+++ b/frontend/src/components/Legend.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Box, Typography, Avatar } from '@mui/material';
+import { Phone } from '@mui/icons-material';
+import { sourceLogo } from '../utils';
+
+function Legend({ bookings }) {
+  const gites = Array.from(
+    new Map(bookings.map(b => [b.giteNom, b.couleur])).entries()
+  );
+  const sources = Array.from(new Set(bookings.map(b => b.source)));
+
+  return (
+    <Box sx={{ mb: 2, fontSize: 12 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+          gap: 1,
+          mb: 0.5
+        }}
+      >
+        {gites.map(([name, color]) => (
+          <Box key={name} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Box
+              sx={{
+                width: 10,
+                height: 10,
+                bgcolor: color,
+                borderRadius: '50%',
+                border: '1px solid rgba(0,0,0,0.3)'
+              }}
+            />
+            <Typography variant="caption">{name}</Typography>
+          </Box>
+        ))}
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+          gap: 1
+        }}
+      >
+        {sources.map(type => {
+          const logo = sourceLogo(type);
+          return (
+            <Box key={type} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Avatar
+                src={logo || undefined}
+                sx={{ width: 16, height: 16, bgcolor: logo ? '#fff' : 'transparent' }}
+              >
+                {!logo && <Phone sx={{ fontSize: 14 }} />}
+              </Avatar>
+              <Typography variant="caption">{type}</Typography>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}
+
+export default Legend;

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,0 +1,16 @@
+import airbnbLogo from './assets/logos/airbnb.svg';
+import abritelLogo from './assets/logos/abritel.svg';
+import gdfLogo from './assets/logos/gitesdefrance.svg';
+
+export function sourceLogo(type) {
+  switch (type) {
+    case 'Airbnb':
+      return airbnbLogo;
+    case 'Abritel':
+      return abritelLogo;
+    case 'GitesDeFrance':
+      return gdfLogo;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
- centralize logo selection with shared `sourceLogo` utility
- add legend displaying gite colors and booking source logos
- render the legend between the calendar bar and today's arrivals

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: react-scripts not found; attempted install returned 403)


------
https://chatgpt.com/codex/tasks/task_e_6891df9c2f9c8322bde08735c213f18e