### PR TITLE
Display gite initials with source-based colors

### DIFF
--- a/frontend/src/components/ArrivalsList.js
+++ b/frontend/src/components/ArrivalsList.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Box, Typography, List, ListItem, ListItemAvatar, Avatar, ListItemText, Card, CardContent } from '@mui/material';
 import dayjs from 'dayjs';
-import { Phone } from '@mui/icons-material';
-import { sourceLogo } from '../utils';
+import { sourceColor, giteInitial } from '../utils';
 
 /**
  * Liste des arrivées à venir (aujourd'hui + 6 jours).
@@ -32,20 +31,20 @@ function ArrivalsList({ bookings, errors }) {
             </Typography>
             <List>
               {groupes[key].map((ev, idx) => {
-                const logo = sourceLogo(ev.source);
+                const color = sourceColor(ev.source);
+                const initial = giteInitial(ev.giteId);
                 return (
-                  <ListItem key={idx} sx={{ bgcolor: ev.couleur + '33', mb: 1 }}>
+                  <ListItem key={idx} sx={{ bgcolor: color + '33', mb: 1 }}>
                     <ListItemAvatar>
                       <Avatar
-                        src={logo || undefined}
                         sx={{
-                          bgcolor: logo ? '#fff' : ev.couleur,
+                          bgcolor: color,
                           boxShadow: 1,
                           transition: 'transform 0.2s',
                           '&:hover': { transform: 'scale(1.05)' }
                         }}
                       >
-                        {!logo && <Phone />}
+                        {initial}
                       </Avatar>
                     </ListItemAvatar>
                     <ListItemText
@@ -70,20 +69,20 @@ function ArrivalsList({ bookings, errors }) {
           <Typography variant="h6">Prochains jours</Typography>
           <List>
             {groupes.next.map((ev, idx) => {
-              const logo = sourceLogo(ev.source);
+              const color = sourceColor(ev.source);
+              const initial = giteInitial(ev.giteId);
               return (
                 <ListItem key={idx}>
                   <ListItemAvatar>
                     <Avatar
-                      src={logo || undefined}
                       sx={{
-                        bgcolor: logo ? '#fff' : ev.couleur,
+                        bgcolor: color,
                         boxShadow: 1,
                         transition: 'transform 0.2s',
                         '&:hover': { transform: 'scale(1.05)' }
                       }}
                     >
-                      {!logo && <Phone />}
+                      {initial}
                     </Avatar>
                   </ListItemAvatar>
                   <ListItemText

--- a/frontend/src/components/CalendarBar.js
+++ b/frontend/src/components/CalendarBar.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Box, Typography, Tooltip, Avatar, Card, CardContent } from '@mui/material';
-import { Phone } from '@mui/icons-material';
 import { keyframes } from '@mui/system';
 import dayjs from 'dayjs';
-import { sourceLogo } from '../utils';
+import { sourceColor, giteInitial } from '../utils';
 
 // Animation légère pour les arrivées du jour
 const pulse = keyframes`
@@ -15,8 +14,8 @@ const pulse = keyframes`
 /**
  * Barre de calendrier sur 7 jours.
  * Les réservations sont représentées par des pastilles colorées
- * (une couleur par gîte). Tooltip au survol pour voir le détail.
- */
+ * (une couleur par source). Tooltip au survol pour voir le détail.
+*/
 function CalendarBar({ bookings, errors }) {
   // Construction de la structure { date -> [events] }
   const days = Array.from({ length: 7 }).map((_, i) => {
@@ -38,7 +37,8 @@ function CalendarBar({ bookings, errors }) {
               </Typography>
               <Box sx={{ display: 'flex', justifyContent: 'center', gap: 0.5, mt: 0.5 }}>
                 {events.slice(0, 3).map((ev, idx) => {
-                  const logo = sourceLogo(ev.source);
+                  const color = sourceColor(ev.source);
+                  const initial = giteInitial(ev.giteId);
                   return (
                     <Tooltip
                       key={idx}
@@ -46,9 +46,8 @@ function CalendarBar({ bookings, errors }) {
                       arrow
                     >
                       <Avatar
-                        src={logo || undefined}
                         sx={{
-                          bgcolor: logo ? '#fff' : ev.couleur,
+                          bgcolor: color,
                           width: 24,
                           height: 24,
                           fontSize: 16,
@@ -58,7 +57,7 @@ function CalendarBar({ bookings, errors }) {
                           animation: dayjs(ev.debut).isSame(dayjs(), 'day') ? `${pulse} 2s infinite` : 'none'
                         }}
                       >
-                        {!logo && <Phone fontSize="inherit" />}
+                        {initial}
                       </Avatar>
                     </Tooltip>
                   );

--- a/frontend/src/components/Legend.js
+++ b/frontend/src/components/Legend.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import { Box, Typography, Avatar } from '@mui/material';
-import { Phone } from '@mui/icons-material';
-import { sourceLogo } from '../utils';
+import { sourceColor, giteInitial } from '../utils';
 
 function Legend({ bookings }) {
   const gites = Array.from(
-    new Map(bookings.map(b => [b.giteNom, b.couleur])).entries()
+    new Map(bookings.map(b => [b.giteId, b.giteNom])).entries()
   );
   const sources = Array.from(new Set(bookings.map(b => b.source)));
 
@@ -20,17 +19,11 @@ function Legend({ bookings }) {
           mb: 0.5
         }}
       >
-        {gites.map(([name, color]) => (
-          <Box key={name} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <Box
-              sx={{
-                width: 10,
-                height: 10,
-                bgcolor: color,
-                borderRadius: '50%',
-                border: '1px solid rgba(0,0,0,0.3)'
-              }}
-            />
+        {gites.map(([id, name]) => (
+          <Box key={id} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Avatar sx={{ width: 16, height: 16, fontSize: 12 }}>
+              {giteInitial(id)}
+            </Avatar>
             <Typography variant="caption">{name}</Typography>
           </Box>
         ))}
@@ -43,20 +36,20 @@ function Legend({ bookings }) {
           gap: 1
         }}
       >
-        {sources.map(type => {
-          const logo = sourceLogo(type);
-          return (
-            <Box key={type} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Avatar
-                src={logo || undefined}
-                sx={{ width: 16, height: 16, bgcolor: logo ? '#fff' : 'transparent' }}
-              >
-                {!logo && <Phone sx={{ fontSize: 14 }} />}
-              </Avatar>
-              <Typography variant="caption">{type}</Typography>
-            </Box>
-          );
-        })}
+        {sources.map(type => (
+          <Box key={type} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Box
+              sx={{
+                width: 10,
+                height: 10,
+                bgcolor: sourceColor(type),
+                borderRadius: '50%',
+                border: '1px solid rgba(0,0,0,0.3)'
+              }}
+            />
+            <Typography variant="caption">{type}</Typography>
+          </Box>
+        ))}
       </Box>
     </Box>
   );

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,16 +1,29 @@
-import airbnbLogo from './assets/logos/airbnb.svg';
-import abritelLogo from './assets/logos/abritel.svg';
-import gdfLogo from './assets/logos/gitesdefrance.svg';
-
-export function sourceLogo(type) {
+export function sourceColor(type) {
   switch (type) {
     case 'Airbnb':
-      return airbnbLogo;
+      return '#E53935';
     case 'Abritel':
-      return abritelLogo;
-    case 'GitesDeFrance':
-      return gdfLogo;
+      return '#1976D2';
+    case 'Gites de France':
+      return '#FBC02D';
+    case 'Direct':
+      return '#424242';
     default:
-      return null;
+      return '#9E9E9E';
+  }
+}
+
+export function giteInitial(id) {
+  switch (id) {
+    case 'phonsine':
+      return 'P';
+    case 'edmond':
+      return 'E';
+    case 'liberte':
+      return 'L';
+    case 'gree':
+      return 'G';
+    default:
+      return '?';
   }
 }


### PR DESCRIPTION
## Summary
- color booking dots by reservation source
- show gite initials in booking markers and legend

## Testing
- `cd backend && npm test`
- `cd frontend && CI=true npm test` *(fails: react-scripts not found; install attempt blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689210029f2883228e320947927dcd2e