### PR TITLE
Centralize border style variables and add switches for upcoming days

### DIFF
--- a/frontend/src/components/ArrivalsList.js
+++ b/frontend/src/components/ArrivalsList.js
@@ -15,7 +15,13 @@ import {
 import { Login as LoginIcon, Logout as LogoutIcon } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
 import dayjs from 'dayjs';
-import { sourceColor, giteInitial, eventColor } from '../utils';
+import {
+  sourceColor,
+  giteInitial,
+  eventColor,
+  borderWidth,
+  statusBorderColor
+} from '../utils';
 
 /**
  * Liste des arrivées à venir (aujourd'hui + 6 jours).
@@ -96,7 +102,7 @@ function ArrivalsList({ bookings, errors, statuses, onStatusChange }) {
                 const user = statuses[ev.id]?.user;
                 const bg = eventColor(ev.type);
                 const textColor = theme.palette.getContrastText(bg);
-                const borderWidth = ev.type === 'arrival' ? 3 : 1;
+                const bw = borderWidth(ev.type);
                 return (
                   <ListItem
                     key={ev.id}
@@ -104,10 +110,8 @@ function ArrivalsList({ bookings, errors, statuses, onStatusChange }) {
                       bgcolor: bg,
                       color: textColor,
                       mb: 1,
-                      border: `${borderWidth}px solid`,
-                      borderColor: status
-                        ? theme.palette.success.dark
-                        : theme.palette.error.dark,
+                      border: `${bw}px solid`,
+                      borderColor: statusBorderColor(status),
                       transition: 'background-color 0.3s, border-color 0.3s'
                     }}
                   >
@@ -173,10 +177,20 @@ function ArrivalsList({ bookings, errors, statuses, onStatusChange }) {
               const initial = giteInitial(ev.giteId);
               const bg = eventColor(ev.type);
               const textColor = theme.palette.getContrastText(bg);
+              const status = statuses[ev.id]?.done;
+              const user = statuses[ev.id]?.user;
+              const bw = borderWidth(ev.type);
               return (
                 <ListItem
                   key={ev.id}
-                  sx={{ bgcolor: bg, color: textColor, mb: 1, borderRadius: 1 }}
+                  sx={{
+                    bgcolor: bg,
+                    color: textColor,
+                    mb: 1,
+                    border: `${bw}px solid`,
+                    borderColor: statusBorderColor(status),
+                    transition: 'background-color 0.3s, border-color 0.3s'
+                  }}
                 >
                   <ListItemAvatar>
                     <Avatar
@@ -202,6 +216,18 @@ function ArrivalsList({ bookings, errors, statuses, onStatusChange }) {
                         <LogoutIcon fontSize="small" />
                         <LoginIcon fontSize="small" />
                       </>
+                    )}
+                    <Switch
+                      size="small"
+                      checked={Boolean(status)}
+                      onChange={() => onStatusChange(ev.id, !status)}
+                    />
+                    {status && user && (
+                      <Chip
+                        avatar={<Avatar>{user[0]}</Avatar>}
+                        label={user}
+                        size="small"
+                      />
                     )}
                   </Box>
                 </ListItem>

--- a/frontend/src/components/CalendarBar.js
+++ b/frontend/src/components/CalendarBar.js
@@ -2,7 +2,13 @@ import React from 'react';
 import { Box, Typography, Tooltip, Avatar, Card, CardContent } from '@mui/material';
 import { keyframes } from '@mui/system';
 import dayjs from 'dayjs';
-import { sourceColor, giteInitial, eventColor } from '../utils';
+import {
+  sourceColor,
+  giteInitial,
+  eventColor,
+  borderWidth,
+  borderColor
+} from '../utils';
 
 // Animation légère pour les arrivées du jour
 const pulse = keyframes`
@@ -63,7 +69,8 @@ function CalendarBar({ bookings, errors }) {
                 {events.slice(0, 3).map((ev, idx) => {
                   const color = sourceColor(ev.source);
                   const initial = giteInitial(ev.giteId);
-                  const borderColor = eventColor(ev.type);
+                  const borderClr = borderColor(ev.type);
+                  const bw = borderWidth(ev.type);
                   return (
                     <Tooltip
                       key={idx}
@@ -77,8 +84,8 @@ function CalendarBar({ bookings, errors }) {
                           height: 24,
                           fontSize: 16,
                           boxShadow: 2,
-                          border: '2px solid',
-                          borderColor,
+                          border: `${bw}px solid`,
+                          borderColor: borderClr,
                           transition: 'transform 0.2s',
                           '&:hover': { transform: 'scale(1.1)' },
                           animation: dayjs(ev.date).isSame(dayjs(), 'day') ? `${pulse} 2s infinite` : 'none'

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -35,3 +35,32 @@ export function giteInitial(id) {
       return '?';
   }
 }
+
+export const BORDER = {
+  widths: {
+    arrival: 3,
+    depart: 1,
+    both: 2
+  },
+  colors: {
+    arrival: COLORS.events.arrival,
+    depart: COLORS.events.depart,
+    both: COLORS.events.both
+  },
+  status: {
+    done: COLORS.events.arrival,
+    pending: COLORS.events.depart
+  }
+};
+
+export function borderWidth(type) {
+  return BORDER.widths[type] || BORDER.widths.both;
+}
+
+export function borderColor(type) {
+  return BORDER.colors[type] || BORDER.colors.both;
+}
+
+export function statusBorderColor(done) {
+  return done ? BORDER.status.done : BORDER.status.pending;
+}


### PR DESCRIPTION
## Summary
- centralize border widths and colors in `utils.js`
- apply border helpers across calendar and arrival cards
- add status switch to "Prochains jours" entries

## Testing
- `npm test` (backend)
- `CI=true npm test` *(fails: react-scripts: not found; install forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68935aaf1c88832286db892729257b3f