### PR TITLE
Limit upcoming days and refresh calendars

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -174,6 +174,17 @@ app.get('/api/arrivals', (req, res) => {
   });
 });
 
+app.post('/api/reload-icals', async (req, res) => {
+  try {
+    reservations = [];
+    erreurs = new Set();
+    await chargerCalendriers();
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
 // Récupération des statuts
 app.get('/api/statuses', (req, res) => {
   res.json(readStatuses());

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,7 +3,12 @@ import Login from './components/Login';
 import CalendarBar from './components/CalendarBar';
 import ArrivalsList from './components/ArrivalsList';
 import Loader from './components/Loader';
-import { fetchArrivals, fetchStatuses, updateStatus } from './services/api';
+import {
+  fetchArrivals,
+  fetchStatuses,
+  updateStatus,
+  refreshCalendars
+} from './services/api';
 import { Box } from '@mui/material';
 import Legend from './components/Legend';
 
@@ -52,7 +57,9 @@ function App() {
 
   const handleRefresh = () => {
     setRefreshing(true);
-    loadData().finally(() => setRefreshing(false));
+    refreshCalendars()
+      .then(() => loadData())
+      .finally(() => setRefreshing(false));
   };
 
   if (!auth) return <Login onLogin={handleLogin} />;

--- a/frontend/src/components/ArrivalsList.js
+++ b/frontend/src/components/ArrivalsList.js
@@ -83,7 +83,9 @@ function ArrivalsList({ bookings, errors, statuses, onStatusChange }) {
   const groupes = {
     today: events.filter(b => b.date.isSame(today, 'day')),
     tomorrow: events.filter(b => b.date.isSame(tomorrow, 'day')),
-    next: events.filter(b => b.date.isAfter(tomorrow, 'day'))
+    next: events.filter(
+      b => b.date.isAfter(tomorrow, 'day') && b.date.diff(today, 'day') <= 7
+    )
   };
 
   return (
@@ -101,14 +103,17 @@ function ArrivalsList({ bookings, errors, statuses, onStatusChange }) {
                 const status = statuses[ev.id]?.done;
                 const user = statuses[ev.id]?.user;
                 const bg = eventColor(ev.type);
-                const textColor = theme.palette.getContrastText(bg);
+                const itemBg = status ? theme.palette.grey[200] : bg;
+                const textColor = status
+                  ? theme.palette.text.primary
+                  : theme.palette.getContrastText(itemBg);
 
                 const bw = borderWidth(ev.type);
                 return (
                   <ListItem
                     key={ev.id}
                     sx={{
-                      bgcolor: bg,
+                      bgcolor: itemBg,
                       color: textColor,
                       mb: 1,
                       border: `${bw}px solid`,
@@ -177,15 +182,18 @@ function ArrivalsList({ bookings, errors, statuses, onStatusChange }) {
               const color = sourceColor(ev.source);
               const initial = giteInitial(ev.giteId);
               const bg = eventColor(ev.type);
-              const textColor = theme.palette.getContrastText(bg);
               const status = statuses[ev.id]?.done;
               const user = statuses[ev.id]?.user;
+              const itemBg = status ? theme.palette.grey[200] : bg;
+              const textColor = status
+                ? theme.palette.text.primary
+                : theme.palette.getContrastText(itemBg);
               const bw = borderWidth(ev.type);
               return (
                 <ListItem
                   key={ev.id}
                   sx={{
-                    bgcolor: bg,
+                    bgcolor: itemBg,
                     color: textColor,
                     mb: 1,
                     border: `${bw}px solid`,

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -3,6 +3,7 @@ const API_BASE = IS_PROD ? '' : 'http://localhost:3001';
 
 const ARRIVALS_URL = `${API_BASE}/api/arrivals`;
 const STATUS_URL = `${API_BASE}/api/statuses`;
+const REFRESH_URL = `${API_BASE}/api/reload-icals`;
 
 export async function fetchArrivals() {
   const res = await fetch(ARRIVALS_URL);
@@ -24,6 +25,12 @@ export async function updateStatus(id, done, user) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ done, user })
   });
+  if (!res.ok) throw new Error('HTTP ' + res.status);
+  return res.json();
+}
+
+export async function refreshCalendars() {
+  const res = await fetch(REFRESH_URL, { method: 'POST' });
   if (!res.ok) throw new Error('HTTP ' + res.status);
   return res.json();
 }


### PR DESCRIPTION
## Summary
- Restrict upcoming section to show only seven days ahead
- Grey out cards when their switch is active
- Add API endpoint and client hook to reload calendars via refresh button

## Testing
- `npm test` (backend)
- `CI=true npm test` *(fails: react-scripts not found)*
- `npm install --no-save react-scripts` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68944c69a93083228e6e2b8ce8d4a4b2