### PR TITLE
Expose full-year arrivals and add availability popup

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -161,13 +161,15 @@ async function chargerCalendriers() {
     }
   }
 
-  // Filtrage des événements qui chevauchent les 7 prochains jours
-  const aujourdHui = dayjs().startOf('day');
-  const limite = aujourdHui.add(7, 'day');
+  // Filtrage des événements qui chevauchent la période
+  // allant de J-5 au 31 décembre de l'année courante.
+  const today = dayjs().startOf('day');
+  const startWindow = today.subtract(5, 'day');
+  const endWindow = today.endOf('year');
   reservations = reservations.filter(ev => {
     const debut = dayjs(ev.debut);
     const fin = dayjs(ev.fin);
-    return debut.isBefore(limite) && fin.isAfter(aujourdHui.subtract(1, 'day'));
+    return debut.isBefore(endWindow.add(1, 'day')) && fin.isAfter(startWindow);
   });
 }
 
@@ -195,10 +197,18 @@ await chargerCalendriers();
 
 // --- Endpoint JSON ---
 app.get('/api/arrivals', (req, res) => {
+  const today = dayjs().startOf('day');
+  const startWindow = today.subtract(5, 'day');
+  const endWindow = today.endOf('year');
+  const dates = [];
+  for (let d = startWindow; !d.isAfter(endWindow); d = d.add(1, 'day')) {
+    dates.push(d.format('YYYY-MM-DD'));
+  }
   res.json({
     genereLe: new Date().toISOString(),
     reservations,
-    erreurs: Array.from(erreurs)
+    erreurs: Array.from(erreurs),
+    dates
   });
 });
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import {
 } from './services/api';
 import { Box } from '@mui/material';
 import Legend from './components/Legend';
+import AvailabilityDialog from './components/AvailabilityDialog';
 
 // Clé utilisée pour mémoriser l'authentification en localStorage
 const AUTH_KEY = 'wt-authenticated';
@@ -25,6 +26,7 @@ function App() {
     localStorage.getItem(USER_KEY) || 'Soaz'
   );
   const [refreshing, setRefreshing] = useState(false);
+  const [availabilityOpen, setAvailabilityOpen] = useState(false);
 
   // Chargement des données après authentification
   useEffect(() => {
@@ -77,12 +79,18 @@ function App() {
         }}
         onRefresh={handleRefresh}
         refreshing={refreshing}
+        onOpenAvailability={() => setAvailabilityOpen(true)}
       />
       <ArrivalsList
         bookings={data.reservations}
         errors={data.erreurs}
         statuses={statuses}
         onStatusChange={handleStatusChange}
+      />
+      <AvailabilityDialog
+        open={availabilityOpen}
+        onClose={() => setAvailabilityOpen(false)}
+        bookings={data.reservations}
       />
     </Box>
   );

--- a/frontend/src/components/AvailabilityDialog.js
+++ b/frontend/src/components/AvailabilityDialog.js
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  IconButton,
+  Box,
+  Chip,
+  Typography,
+  Card,
+  TextField
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import dayjs from 'dayjs';
+import 'dayjs/locale/fr';
+import useAvailability from '../hooks/useAvailability';
+
+export default function AvailabilityDialog({ open, onClose, bookings }) {
+  const [arrival, setArrival] = useState(dayjs());
+  const [departure, setDeparture] = useState(dayjs().add(1, 'day'));
+  const availability = useAvailability(bookings, arrival, departure);
+
+  const handleArrival = date => {
+    if (!date) return;
+    setArrival(date);
+    if (!date.add(1, 'day').isBefore(departure)) {
+      setDeparture(date.add(1, 'day'));
+    }
+  };
+
+  const handleDeparture = date => {
+    if (!date) return;
+    if (date.isBefore(arrival.add(1, 'day'))) {
+      setDeparture(arrival.add(1, 'day'));
+    } else {
+      setDeparture(date);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth>
+      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        Choisir des dates
+        <IconButton aria-label="Fermer" onClick={onClose}>
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+          <TextField
+            label="Arrivée"
+            type="date"
+            value={arrival.format('YYYY-MM-DD')}
+            onChange={e => handleArrival(dayjs(e.target.value))}
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            label="Départ"
+            type="date"
+            value={departure.format('YYYY-MM-DD')}
+            onChange={e => handleDeparture(dayjs(e.target.value))}
+            InputLabelProps={{ shrink: true }}
+            inputProps={{ min: arrival.add(1, 'day').format('YYYY-MM-DD') }}
+          />
+        </Box>
+        {availability.length > 0 && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {availability.map(g => (
+              <Card key={g.id} sx={{ p: 1 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <Typography>{g.name}</Typography>
+                  <Chip
+                    label={g.free ? 'Libre' : 'Occupé'}
+                    color={g.free ? 'success' : 'error'}
+                    size="small"
+                  />
+                </Box>
+                <Box sx={{ display: 'flex', mt: 1 }}>
+                  {g.segments.map(s => (
+                    <Box
+                      key={s.date}
+                      sx={{
+                        flex: 1,
+                        height: 8,
+                        bgcolor: s.busy ? '#f48fb1' : '#64b5f6'
+                      }}
+                    />
+                  ))}
+                </Box>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 0.5 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    {g.segments[0].date}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {g.segments[g.segments.length - 1].date}
+                  </Typography>
+                </Box>
+              </Card>
+            ))}
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/Legend.js
+++ b/frontend/src/components/Legend.js
@@ -9,9 +9,10 @@ import {
   CircularProgress
 } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import { sourceColor, giteInitial } from '../utils';
 
-function Legend({ bookings, selectedUser, onUserChange, onRefresh, refreshing }) {
+function Legend({ bookings, selectedUser, onUserChange, onRefresh, refreshing, onOpenAvailability }) {
   const gites = Array.from(
     new Map(bookings.map(b => [b.giteId, b.giteNom])).entries()
   );
@@ -35,13 +36,14 @@ function Legend({ bookings, selectedUser, onUserChange, onRefresh, refreshing })
           <MenuItem value="Soaz">Soaz</MenuItem>
           <MenuItem value="Seb">Seb</MenuItem>
         </Select>
-        <IconButton onClick={onRefresh} disabled={refreshing}>
-          {refreshing ? (
-            <CircularProgress size={24} />
-          ) : (
-            <RefreshIcon />
-          )}
-        </IconButton>
+        <Box>
+          <IconButton onClick={onOpenAvailability} sx={{ mr: 1 }}>
+            <CalendarMonthIcon />
+          </IconButton>
+          <IconButton onClick={onRefresh} disabled={refreshing}>
+            {refreshing ? <CircularProgress size={24} /> : <RefreshIcon />}
+          </IconButton>
+        </Box>
       </Box>
       <Box
         sx={{

--- a/frontend/src/hooks/useAvailability.js
+++ b/frontend/src/hooks/useAvailability.js
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
+import { GITES } from '../utils';
+
+function overlaps(start, end, res) {
+  const resStart = dayjs(res.debut);
+  const resEnd = dayjs(res.fin);
+  return start.isBefore(resEnd) && end.isAfter(resStart);
+}
+
+export default function useAvailability(bookings, arrival, departure) {
+  return useMemo(() => {
+    if (!arrival || !departure) return [];
+    const arr = dayjs(arrival).startOf('day');
+    const dep = dayjs(departure).startOf('day');
+    const rangeStart = arr.subtract(3, 'day');
+    const rangeEnd = dep.add(3, 'day');
+    const days = [];
+    for (let d = rangeStart; !d.isAfter(rangeEnd); d = d.add(1, 'day')) {
+      days.push(d);
+    }
+    return GITES.map(g => {
+      const segments = days.map(d => {
+        const busy = bookings.some(b => b.giteId === g.id && overlaps(d, d.add(1, 'day'), b));
+        return { date: d.format('YYYY-MM-DD'), busy };
+      });
+      const occupied = bookings.some(b => b.giteId === g.id && overlaps(arr, dep, b));
+      return { id: g.id, name: g.name, free: !occupied, segments };
+    });
+  }, [bookings, arrival, departure]);
+}

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -14,6 +14,13 @@ export const COLORS = {
   }
 };
 
+export const GITES = [
+  { id: 'phonsine', name: 'Gîte de Phonsine' },
+  { id: 'liberte', name: 'Gîte Le Liberté' },
+  { id: 'gree', name: 'Gîte de la Grée' },
+  { id: 'edmond', name: "Gîte de l'oncle Edmond" }
+];
+
 export function sourceColor(type) {
   return COLORS.sources[type] || COLORS.sources.default;
 }


### PR DESCRIPTION
## Summary
- extend arrivals API to cover full-year window and expose date list
- add availability dialog with date selection and gite status display
- integrate availability button and hook for occupancy calculation

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `CI=true npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b3cc445e8832288e0e9d684d7355e