### PR TITLE
Adjust availability window and legend

### DIFF
--- a/frontend/src/components/AvailabilityDialog.js
+++ b/frontend/src/components/AvailabilityDialog.js
@@ -107,7 +107,7 @@ export default function AvailabilityDialog({ open, onClose, bookings }) {
                         color: s.busy ? '#f48fb1' : '#64b5f6'
                       }}
                     >
-                      {dayjs(s.date).format('DD/MM')}
+                      {dayjs(s.date).format('DD')}
                     </Typography>
                   ))}
                 </Box>

--- a/frontend/src/hooks/useAvailability.js
+++ b/frontend/src/hooks/useAvailability.js
@@ -13,8 +13,8 @@ export default function useAvailability(bookings, arrival, departure) {
     if (!arrival || !departure) return [];
     const arr = dayjs(arrival).startOf('day');
     const dep = dayjs(departure).startOf('day');
-    const rangeStart = arr.subtract(3, 'day');
-    const rangeEnd = dep.add(3, 'day');
+    const rangeStart = arr.subtract(1, 'day');
+    const rangeEnd = dep.add(1, 'day');
     const days = [];
     for (let d = rangeStart; !d.isAfter(rangeEnd); d = d.add(1, 'day')) {
       days.push(d);


### PR DESCRIPTION
## Summary
- Show only day numbers in availability legend
- Limit availability range to one day before arrival and one day after departure

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `CI=true npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ba4cb52fc8322bb2109a0502a8553