### PR TITLE
Color availability dialog

### DIFF
--- a/frontend/src/components/AvailabilityDialog.js
+++ b/frontend/src/components/AvailabilityDialog.js
@@ -72,10 +72,14 @@ export default function AvailabilityDialog({ open, onClose, bookings }) {
             {availability.map(g => (
               <Card key={g.id} sx={{ p: 1 }}>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <Typography>{g.name}</Typography>
+                  <Typography sx={{ color: g.free ? '#64b5f6' : '#f48fb1' }}>{g.name}</Typography>
                   <Chip
                     label={g.free ? 'Libre' : 'Occupé'}
-                    color={g.free ? 'success' : 'error'}
+                    variant="outlined"
+                    sx={{
+                      color: g.free ? '#64b5f6' : '#f48fb1',
+                      borderColor: g.free ? '#64b5f6' : '#f48fb1'
+                    }}
                     size="small"
                   />
                 </Box>


### PR DESCRIPTION
## Summary
- style availability dialog so gite names and status labels use blue for free and pink for busy

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=true npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ba754e6ec8322a67edda76dd65b83