### PR TITLE
Extend arrivals endpoint date range

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -143,15 +143,12 @@ async function chargerCalendriers() {
     }
   }
 
-  // Filtrage des événements qui chevauchent la période
-  // allant de J-5 au 31 décembre de l'année courante.
+  // Filtrage des événements à partir de J-5
   const today = dayjs().startOf('day');
   const startWindow = today.subtract(5, 'day');
-  const endWindow = today.endOf('year');
   reservations = reservations.filter(ev => {
-    const debut = dayjs(ev.debut);
     const fin = dayjs(ev.fin);
-    return debut.isBefore(endWindow.add(1, 'day')) && fin.isAfter(startWindow);
+    return fin.isAfter(startWindow);
   });
 }
 
@@ -181,7 +178,10 @@ await chargerCalendriers();
 app.get('/api/arrivals', (req, res) => {
   const today = dayjs().startOf('day');
   const startWindow = today.subtract(5, 'day');
-  const endWindow = today.endOf('year');
+  const endWindow = reservations.reduce((max, ev) => {
+    const fin = dayjs(ev.fin);
+    return fin.isAfter(max) ? fin : max;
+  }, startWindow);
   const dates = [];
   for (let d = startWindow; !d.isAfter(endWindow); d = d.add(1, 'day')) {
     dates.push(d.format('YYYY-MM-DD'));


### PR DESCRIPTION
## Summary
- Allow reservations beyond the current year by filtering only on dates after J-5
- Generate arrival dates from 5 days before today up to the latest reservation

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `CI=true npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c29a754ec8322ab8f60362c47f228