### PR TITLE
Add range selector

### DIFF
--- a/frontend/src/components/AvailabilityDialog.js
+++ b/frontend/src/components/AvailabilityDialog.js
@@ -8,7 +8,8 @@ import {
   Chip,
   Typography,
   Card,
-  TextField
+  TextField,
+  MenuItem
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import dayjs from 'dayjs';
@@ -22,7 +23,8 @@ dayjs.extend(isSameOrAfter);
 export default function AvailabilityDialog({ open, onClose, bookings }) {
   const [arrival, setArrival] = useState(dayjs());
   const [departure, setDeparture] = useState(dayjs().add(1, 'day'));
-  const availability = useAvailability(bookings, arrival, departure);
+  const [range, setRange] = useState(1);
+  const availability = useAvailability(bookings, arrival, departure, range);
 
   const handleArrival = date => {
     if (!date) return;
@@ -66,6 +68,17 @@ export default function AvailabilityDialog({ open, onClose, bookings }) {
             InputLabelProps={{ shrink: true }}
             inputProps={{ min: arrival.add(1, 'day').format('YYYY-MM-DD') }}
           />
+          <TextField
+            select
+            label="Plage"
+            value={range}
+            onChange={e => setRange(Number(e.target.value))}
+          >
+            <MenuItem value={1}>1 jour</MenuItem>
+            <MenuItem value={2}>2 jours</MenuItem>
+            <MenuItem value={3}>3 jours</MenuItem>
+            <MenuItem value={4}>4 jours</MenuItem>
+          </TextField>
         </Box>
         {availability.length > 0 && (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>

--- a/frontend/src/hooks/useAvailability.js
+++ b/frontend/src/hooks/useAvailability.js
@@ -8,13 +8,13 @@ function overlaps(start, end, res) {
   return start.isBefore(resEnd) && end.isAfter(resStart);
 }
 
-export default function useAvailability(bookings, arrival, departure) {
+export default function useAvailability(bookings, arrival, departure, range = 1) {
   return useMemo(() => {
     if (!arrival || !departure) return [];
     const arr = dayjs(arrival).startOf('day');
     const dep = dayjs(departure).startOf('day');
-    const rangeStart = arr.subtract(1, 'day');
-    const rangeEnd = dep.add(1, 'day');
+    const rangeStart = arr.subtract(range, 'day');
+    const rangeEnd = dep.add(range, 'day');
     const days = [];
     for (let d = rangeStart; !d.isAfter(rangeEnd); d = d.add(1, 'day')) {
       days.push(d);
@@ -27,5 +27,5 @@ export default function useAvailability(bookings, arrival, departure) {
       const occupied = bookings.some(b => b.giteId === g.id && overlaps(arr, dep, b));
       return { id: g.id, name: g.name, free: !occupied, segments };
     });
-  }, [bookings, arrival, departure]);
+  }, [bookings, arrival, departure, range]);
 }


### PR DESCRIPTION
## Summary
- allow selecting 1-4 day ranges around chosen dates in the availability dialog
- make availability hook accept configurable range padding

## Testing
- `npm test` *(fails: Missing script: "test")*
- `CI=true npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c2e20f0648322a1116fc9ce2d086c