### PR TITLE
Add weekday headers to availability bar

### DIFF
--- a/frontend/src/components/AvailabilityDialog.js
+++ b/frontend/src/components/AvailabilityDialog.js
@@ -96,7 +96,22 @@ export default function AvailabilityDialog({ open, onClose, bookings }) {
                     size="small"
                   />
                 </Box>
-                <Box sx={{ display: 'flex', mt: 1 }}>
+                <Box sx={{ display: 'flex', mb: 0.5 }}>
+                  {g.segments.map(s => (
+                    <Typography
+                      key={s.date}
+                      variant="caption"
+                      sx={{
+                        flex: 1,
+                        textAlign: 'center',
+                        color: s.busy ? '#f48fb1' : '#64b5f6'
+                      }}
+                    >
+                      {dayjs(s.date).format('dd')[0].toLowerCase()}
+                    </Typography>
+                  ))}
+                </Box>
+                <Box sx={{ display: 'flex', mt: 0.5 }}>
                   {g.segments.map(s => {
                     const isSelected =
                       dayjs(s.date).isSameOrAfter(arrival, 'day') &&


### PR DESCRIPTION
## Summary
- show french weekday initials above each availability segment
- fine-tune spacing for clarity

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `CI=true npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c3d634d288322b0c14483c9fe1b3c