### PR TITLE
Replace date picker with react-date-range

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^5.18.0",
         "dayjs": "^1.11.13",
         "react": "^18.3.1",
+        "react-date-range": "^1.4.0",
         "react-dom": "^18.3.1",
         "react-scripts": "^5.0.1"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,9 +12,9 @@
     "@mui/icons-material": "^5.18.0",
     "@mui/material": "^5.18.0",
     "dayjs": "^1.11.13",
-    "mui-daterange-picker": "^1.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-date-range": "^1.4.0",
     "react-scripts": "^5.0.1"
   },
   "browserslist": {

--- a/frontend/src/components/AvailabilityDialog.js
+++ b/frontend/src/components/AvailabilityDialog.js
@@ -10,9 +10,12 @@ import {
   Card,
   TextField,
   MenuItem,
-  Button
+  Button,
+  Popover
 } from '@mui/material';
-import DateRangePicker from 'mui-daterange-picker';
+import { DateRange } from 'react-date-range';
+import 'react-date-range/dist/styles.css';
+import 'react-date-range/dist/theme/default.css';
 import CloseIcon from '@mui/icons-material/Close';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import dayjs from 'dayjs';
@@ -38,11 +41,15 @@ export default function AvailabilityDialog({ open, onClose, bookings }) {
   const [showReservation, setShowReservation] = useState(false);
   const [selectedGite, setSelectedGite] = useState(null);
   const [note, setNote] = useState('');
-  const [openPicker, setOpenPicker] = useState(false);
+  const [anchorEl, setAnchorEl] = useState(null);
   const availability = useAvailability(bookings, arrival, departure, range);
 
-  const togglePicker = () => {
-    setOpenPicker(!openPicker);
+  const handleOpenPicker = event => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClosePicker = () => {
+    setAnchorEl(null);
   };
 
   const handleRangeChange = newRange => {
@@ -92,14 +99,22 @@ export default function AvailabilityDialog({ open, onClose, bookings }) {
                 <TextField
                   label="Période"
                   value={`${arrival.format('YYYY-MM-DD')} - ${departure.format('YYYY-MM-DD')}`}
-                  onClick={togglePicker}
+                  onClick={handleOpenPicker}
                   InputProps={{ readOnly: true }}
                 />
-                <DateRangePicker
-                  open={openPicker}
-                  toggle={togglePicker}
-                  onChange={handleRangeChange}
-                />
+                <Popover
+                  open={Boolean(anchorEl)}
+                  anchorEl={anchorEl}
+                  onClose={handleClosePicker}
+                  anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                >
+                  <DateRange
+                    ranges={[
+                      { startDate: arrival.toDate(), endDate: departure.toDate(), key: 'selection' }
+                    ]}
+                    onChange={item => handleRangeChange(item.selection)}
+                  />
+                </Popover>
                 <TextField
                   select
                   label="Plage"


### PR DESCRIPTION
## Summary
- swap MUI date range picker for react-date-range in AvailabilityDialog
- update frontend dependencies to include react-date-range

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `CI=true npm test` (frontend) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c72dbba208322ba9138634115ada0