### PR TITLE
Add school holidays API and calendar highlighting

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -5,6 +5,7 @@ const ARRIVALS_URL = `${API_BASE}/api/arrivals`;
 const STATUS_URL = `${API_BASE}/api/statuses`;
 const REFRESH_URL = `${API_BASE}/api/reload-icals`;
 export const SAVE_RESERVATION = `${API_BASE}/api/save-reservation`;
+const HOLIDAYS_URL = `${API_BASE}/api/school-holidays`;
 
 export async function fetchArrivals() {
   const res = await fetch(ARRIVALS_URL);
@@ -32,6 +33,12 @@ export async function updateStatus(id, done, user) {
 
 export async function refreshCalendars() {
   const res = await fetch(REFRESH_URL, { method: 'POST' });
+  if (!res.ok) throw new Error('HTTP ' + res.status);
+  return res.json();
+}
+
+export async function fetchSchoolHolidays() {
+  const res = await fetch(HOLIDAYS_URL);
   if (!res.ok) throw new Error('HTTP ' + res.status);
   return res.json();
 }


### PR DESCRIPTION
## Summary
- fetch and cache French school holidays for the current and next year
- expose `/api/school-holidays` endpoint
- highlight vacation days in the booking calendar

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689ccdc054a883228a294eb32151e24d