### PR TITLE
Improve date picker holiday styling

### DIFF
--- a/frontend/src/components/AvailabilityDialog.js
+++ b/frontend/src/components/AvailabilityDialog.js
@@ -120,6 +120,14 @@ export default function AvailabilityDialog({ open, onClose, bookings }) {
   const renderDayContent = date => {
     const formatted = dayjs(date).format('YYYY-MM-DD');
     const isHoliday = holidayDates.has(formatted);
+    const d = dayjs(date);
+    const isSelected = !d.isBefore(arrival, 'day') && !d.isAfter(departure, 'day');
+    let backgroundColor;
+    if (isSelected && isHoliday) {
+      backgroundColor = '#90caf9';
+    } else if (isHoliday) {
+      backgroundColor = '#ffd2a5';
+    }
     return (
       <div
         style={{
@@ -128,11 +136,12 @@ export default function AvailabilityDialog({ open, onClose, bookings }) {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          backgroundColor: isHoliday ? '#ffd2a5ff' : undefined,
+          backgroundColor,
+          color: isSelected ? '#fff' : '#555',
           borderRadius: '5%'
         }}
       >
-        {dayjs(date).date()}
+        {d.date()}
       </div>
     );
   };


### PR DESCRIPTION
## Summary
- Improve readability of dates in availability picker
- Show selected holiday dates in lighter blue and keep normal selections above holiday highlights

## Testing
- `npm test` (fails: Missing script "test")
- `CI=true npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689cd99caa6c8322873d64eb44d1d31a