### PR TITLE
Use hidden link for reservation opening

### DIFF
--- a/frontend/src/components/AvailabilityDialog.js
+++ b/frontend/src/components/AvailabilityDialog.js
@@ -147,7 +147,15 @@ export default function AvailabilityDialog({ open, onClose, bookings }) {
       if (link) {
         const start = arrival.format('YYYY-MM-DD');
         const end = departure.format('YYYY-MM-DD');
-        window.open(`${link}/edit-selected-dates/${start}/${end}`, '_blank');
+        const url = `${link}/edit-selected-dates/${start}/${end}`;
+        const a = document.createElement('a');
+        a.href = url;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
       }
     } catch (e) {
       setSaving(false);


### PR DESCRIPTION
## Summary
- open reservation URLs via temporary hidden link

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=true npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689db8a4c04883228684a8d1aa9cac31