### PR TITLE
Implement sliding panels with navigation

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import dayjs from 'dayjs';
 import Login from './components/Login';
 import CalendarBar from './components/CalendarBar';
 import ArrivalsList from './components/ArrivalsList';
@@ -9,9 +10,21 @@ import {
   updateStatus,
   refreshCalendars
 } from './services/api';
-import { Box } from '@mui/material';
+import {
+  Box,
+  BottomNavigation,
+  BottomNavigationAction,
+  Typography
+} from '@mui/material';
+import TimerIcon from '@mui/icons-material/Timer';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import EditIcon from '@mui/icons-material/Edit';
+import SettingsIcon from '@mui/icons-material/Settings';
 import Legend from './components/Legend';
-import AvailabilityDialog from './components/AvailabilityDialog';
+import {
+  AvailabilitySelect,
+  ReservationForm
+} from './components/AvailabilityPanels';
 
 // Clé utilisée pour mémoriser l'authentification en localStorage
 const AUTH_KEY = 'wt-authenticated';
@@ -26,7 +39,11 @@ function App() {
     localStorage.getItem(USER_KEY) || 'Soaz'
   );
   const [refreshing, setRefreshing] = useState(false);
-  const [availabilityOpen, setAvailabilityOpen] = useState(false);
+  const [panel, setPanel] = useState(0);
+  const [arrival, setArrival] = useState(dayjs());
+  const [departure, setDeparture] = useState(dayjs().add(1, 'day'));
+  const [range, setRange] = useState(1);
+  const [selectedGite, setSelectedGite] = useState(null);
 
   // Chargement des données après authentification
   useEffect(() => {
@@ -68,31 +85,87 @@ function App() {
   if (loading) return <Loader />;
 
   return (
-    <Box sx={{ maxWidth: 800, mx: 'auto', width: '100%' }}>
-      <CalendarBar bookings={data.reservations} errors={data.erreurs} />
-      <Legend
-        bookings={data.reservations}
-        selectedUser={selectedUser}
-        onUserChange={user => {
-          setSelectedUser(user);
-          localStorage.setItem(USER_KEY, user);
-        }}
-        onRefresh={handleRefresh}
-        refreshing={refreshing}
-        onOpenAvailability={() => setAvailabilityOpen(true)}
-      />
-      <ArrivalsList
-        bookings={data.reservations}
-        errors={data.erreurs}
-        statuses={statuses}
-        onStatusChange={handleStatusChange}
-      />
-      <AvailabilityDialog
-        open={availabilityOpen}
-        onClose={() => setAvailabilityOpen(false)}
-        bookings={data.reservations}
-      />
-    </Box>
+    <>
+      <Box sx={{ maxWidth: 400, mx: 'auto', width: '100%', overflow: 'hidden', pb: 7 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            width: '400%',
+            transform: `translateX(-${panel * 100}%)`,
+            transition: 'transform 0.3s'
+          }}
+        >
+          <Box sx={{ width: '100%', flexShrink: 0 }}>
+            <CalendarBar bookings={data.reservations} errors={data.erreurs} />
+            <Legend
+              bookings={data.reservations}
+              selectedUser={selectedUser}
+              onUserChange={user => {
+                setSelectedUser(user);
+                localStorage.setItem(USER_KEY, user);
+              }}
+              onRefresh={handleRefresh}
+              refreshing={refreshing}
+            />
+            <ArrivalsList
+              bookings={data.reservations}
+              errors={data.erreurs}
+              statuses={statuses}
+              onStatusChange={handleStatusChange}
+            />
+          </Box>
+          <Box sx={{ width: '100%', flexShrink: 0 }}>
+            <AvailabilitySelect
+              bookings={data.reservations}
+              arrival={arrival}
+              setArrival={setArrival}
+              departure={departure}
+              setDeparture={setDeparture}
+              range={range}
+              setRange={setRange}
+              onSelectGite={g => {
+                setSelectedGite(g);
+                setPanel(2);
+              }}
+            />
+          </Box>
+          <Box sx={{ width: '100%', flexShrink: 0 }}>
+            <ReservationForm
+              selectedGite={selectedGite}
+              arrival={arrival}
+              departure={departure}
+              onBack={() => setPanel(1)}
+            />
+          </Box>
+          <Box sx={{ width: '100%', flexShrink: 0, p: 2 }}>
+            <Typography variant="h6">Settings</Typography>
+          </Box>
+        </Box>
+      </Box>
+      <BottomNavigation
+        showLabels={false}
+        value={panel}
+        onChange={(e, value) => setPanel(value)}
+        sx={{ position: 'fixed', bottom: 0, left: 0, width: '100%', bgcolor: '#f48fb1' }}
+      >
+        <BottomNavigationAction
+          icon={<TimerIcon />}
+          sx={{ color: 'white', '&.Mui-selected': { color: 'white' } }}
+        />
+        <BottomNavigationAction
+          icon={<CalendarMonthIcon />}
+          sx={{ color: 'white', '&.Mui-selected': { color: 'white' } }}
+        />
+        <BottomNavigationAction
+          icon={<EditIcon />}
+          sx={{ color: 'white', '&.Mui-selected': { color: 'white' } }}
+        />
+        <BottomNavigationAction
+          icon={<SettingsIcon />}
+          sx={{ color: 'white', '&.Mui-selected': { color: 'white' } }}
+        />
+      </BottomNavigation>
+    </>
   );
 }
 

--- a/frontend/src/components/AvailabilityPanels.js
+++ b/frontend/src/components/AvailabilityPanels.js
@@ -1,0 +1,408 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  TextField,
+  MenuItem,
+  Button,
+  Popover,
+  Card,
+  Typography,
+  Chip,
+  FormControlLabel,
+  Checkbox,
+  CircularProgress,
+  IconButton
+} from '@mui/material';
+import { DateRange } from 'react-date-range';
+import 'react-date-range/dist/styles.css';
+import 'react-date-range/dist/theme/default.css';
+import dayjs from 'dayjs';
+import 'dayjs/locale/fr';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import useAvailability from '../hooks/useAvailability';
+import {
+  SAVE_RESERVATION,
+  fetchSchoolHolidays,
+  fetchPublicHolidays
+} from '../services/api';
+
+dayjs.extend(isSameOrAfter);
+dayjs.locale('fr');
+
+const GITE_LABELS = {
+  phonsine: 'de Tante Phonsine à Néant sur Yvel',
+  gree: 'de la Grée à Néant sur Yvel',
+  edmond: "de l'Oncle Edmond à Néant sur Yvel",
+  liberte: 'du Liberté à Mauron'
+};
+
+const GITE_LINKS = {
+  liberte: 'https://www.airbnb.fr/multicalendar/48504640',
+  gree: 'https://www.airbnb.fr/multicalendar/16674752',
+  phonsine: 'https://www.airbnb.fr/multicalendar/6668903',
+  edmond: 'https://www.airbnb.fr/multicalendar/43504621'
+};
+
+export function AvailabilitySelect({
+  bookings,
+  arrival,
+  setArrival,
+  departure,
+  setDeparture,
+  range,
+  setRange,
+  onSelectGite
+}) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const availability = useAvailability(bookings, arrival, departure, range);
+  const [holidayDates, setHolidayDates] = useState(new Set());
+  const [publicHolidayDates, setPublicHolidayDates] = useState(new Set());
+
+  useEffect(() => {
+    fetchSchoolHolidays()
+      .then(data => {
+        const dates = new Set();
+        data.forEach(h => {
+          let d = dayjs(h.start);
+          const end = dayjs(h.end);
+          for (; !d.isAfter(end, 'day'); d = d.add(1, 'day')) {
+            dates.add(d.format('YYYY-MM-DD'));
+          }
+        });
+        setHolidayDates(dates);
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    fetchPublicHolidays()
+      .then(data => {
+        setPublicHolidayDates(new Set(Object.keys(data)));
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleOpenPicker = event => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClosePicker = () => {
+    setAnchorEl(null);
+  };
+
+  const handleRangeChange = newRange => {
+    if (!newRange.startDate || !newRange.endDate) return;
+    setArrival(dayjs(newRange.startDate));
+    setDeparture(dayjs(newRange.endDate));
+  };
+
+  const handleReserve = g => {
+    onSelectGite(g);
+  };
+
+  const renderDayContent = date => {
+    const formatted = dayjs(date).format('YYYY-MM-DD');
+    const isVacation = holidayDates.has(formatted);
+    const isPublicHoliday = publicHolidayDates.has(formatted);
+    const d = dayjs(date);
+    const isSelected = !d.isBefore(arrival, 'day') && !d.isAfter(departure, 'day');
+    let backgroundColor;
+    if (isSelected && isPublicHoliday) {
+      backgroundColor = '#8a73fbff';
+    } else if (isPublicHoliday) {
+      backgroundColor = '#ffe1a5ff';
+    } else if (isSelected && isVacation) {
+      backgroundColor = '#8a73fbff';
+    } else if (isVacation) {
+      backgroundColor = '#ffe1a5ff';
+    }
+    return (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor,
+          color: isSelected ? '#fff' : '#555',
+          borderRadius: '5%'
+        }}
+      >
+        {d.date()}
+      </div>
+    );
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Choisir des dates
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        <TextField
+          label="Période"
+          value={`${arrival.format('YYYY-MM-DD')} - ${departure.format('YYYY-MM-DD')}`}
+          onClick={handleOpenPicker}
+          InputProps={{ readOnly: true }}
+        />
+        <Popover
+          open={Boolean(anchorEl)}
+          anchorEl={anchorEl}
+          onClose={handleClosePicker}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        >
+          <DateRange
+            ranges={[
+              { startDate: arrival.toDate(), endDate: departure.toDate(), key: 'selection' }
+            ]}
+            onChange={item => handleRangeChange(item.selection)}
+            dayContentRenderer={renderDayContent}
+          />
+        </Popover>
+        <TextField
+          select
+          label="Plage"
+          value={range}
+          onChange={e => setRange(Number(e.target.value))}
+        >
+          <MenuItem value={1}>1 jour</MenuItem>
+          <MenuItem value={2}>2 jours</MenuItem>
+          <MenuItem value={3}>3 jours</MenuItem>
+          <MenuItem value={4}>4 jours</MenuItem>
+        </TextField>
+      </Box>
+      {availability.length > 0 && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {availability.map(g => (
+            <Card key={g.id} sx={{ p: 1 }}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Typography sx={{ color: g.free ? '#64b5f6' : '#f48fb1' }}>
+                  {g.name}
+                </Typography>
+                {g.free ? (
+                  <Button variant="contained" size="small" onClick={() => handleReserve(g)}>
+                    Réserver
+                  </Button>
+                ) : (
+                  <Chip
+                    label="Occupé"
+                    variant="outlined"
+                    sx={{ color: '#f48fb1', borderColor: '#f48fb1' }}
+                    size="small"
+                  />
+                )}
+              </Box>
+              <Box sx={{ display: 'flex', mb: 0.5 }}>
+                {g.segments.map(s => (
+                  <Typography
+                    key={s.date}
+                    variant="caption"
+                    sx={{
+                      flex: 1,
+                      textAlign: 'center',
+                      color: s.busy ? '#f48fb1' : '#64b5f6'
+                    }}
+                  >
+                    {dayjs(s.date).format('dd')[0].toLowerCase()}
+                  </Typography>
+                ))}
+              </Box>
+              <Box sx={{ display: 'flex', mt: 0.5 }}>
+                {g.segments.map(s => {
+                  const isSelected =
+                    dayjs(s.date).isSameOrAfter(arrival, 'day') &&
+                    dayjs(s.date).isBefore(departure, 'day');
+                  return (
+                    <Box
+                      key={s.date}
+                      sx={{
+                        flex: 1,
+                        height: isSelected ? 8 : 4,
+                        bgcolor: s.busy ? '#f48fb1' : '#64b5f6'
+                      }}
+                    />
+                  );
+                })}
+              </Box>
+              <Box sx={{ display: 'flex', mt: 0.5 }}>
+                {g.segments.map(s => (
+                  <Typography
+                    key={s.date}
+                    variant="caption"
+                    sx={{
+                      flex: 1,
+                      textAlign: 'center',
+                      color: s.busy ? '#f48fb1' : '#64b5f6'
+                    }}
+                  >
+                    {dayjs(s.date).format('DD')}
+                  </Typography>
+                ))}
+              </Box>
+            </Card>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export function ReservationForm({ selectedGite, arrival, departure, onBack }) {
+  const [name, setName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [draps, setDraps] = useState(false);
+  const [info, setInfo] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(false);
+  const [airbnbUrl, setAirbnbUrl] = useState(null);
+
+  useEffect(() => {
+    const parts = [];
+    if (name) parts.push(`N: ${name}`);
+    if (phone) parts.push(`T: ${phone}`);
+    parts.push(`Draps: ${draps ? 'oui' : 'non'}`);
+    setInfo(parts.join('\n'));
+  }, [name, phone, draps]);
+
+  const handlePhoneChange = e => {
+    const digits = e.target.value.replace(/\D/g, '').slice(0, 10);
+    const formatted = digits.replace(/(\d{2})(?=\d)/g, '$1 ').trim();
+    setPhone(formatted);
+  };
+
+  const handleSave = () => {
+    if (!selectedGite) return;
+    setSaving(true);
+    setSaveError(false);
+    setAirbnbUrl(null);
+    navigator.clipboard?.writeText(info).catch(() => {});
+    (async () => {
+      const payload = {
+        giteId: selectedGite.id,
+        name,
+        start: arrival.format('DD/MM/YYYY'),
+        end: departure.format('DD/MM/YYYY'),
+        summary: info.replace(/\n/g, ' ')
+      };
+      try {
+        const res = await fetch(SAVE_RESERVATION, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        if (!res.ok) throw new Error('save failed');
+        const start = arrival.format('YYYY-MM-DD');
+        const end = departure.subtract(1, 'day').format('YYYY-MM-DD');
+        const link = GITE_LINKS[selectedGite.id];
+        const url = link ? `${link}/edit-selected-dates/${start}/${end}` : null;
+        setAirbnbUrl(url);
+      } catch (e) {
+        setSaveError(true);
+      } finally {
+        setSaving(false);
+      }
+    })();
+  };
+
+  const reservationText = selectedGite
+    ? `Bonjour,\nJe vous confirme votre réservation pour le gîte ${GITE_LABELS[selectedGite.id]} du ${arrival
+        .locale('fr')
+        .format('D MMMM YYYY')} à partir de 17h au ${departure
+        .locale('fr')
+        .format('D MMMM YYYY')} midi.\nMerci Beaucoup,\nSoazig Molinier`
+    : '';
+
+  const nights = departure.diff(arrival, 'day');
+
+  return (
+    <Box sx={{ p: 2, overflowY: 'auto' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <IconButton onClick={onBack}>
+          <ArrowBackIcon sx={{ fontSize: 32 }} />
+        </IconButton>
+        <Typography variant="h6">Réservation</Typography>
+      </Box>
+      {selectedGite && (
+        <Typography variant="subtitle2" sx={{ color: 'grey.600', mb: 2 }}>
+          {selectedGite.name} {arrival.format('DD/MM/YYYY')} - {departure.format('DD/MM/YYYY')}
+          <Chip
+            label={`${nights} nuit${nights > 1 ? 's' : ''}`}
+            size="small"
+            sx={{ ml: 1, bgcolor: '#f48fb1', color: '#fff' }}
+          />
+        </Typography>
+      )}
+      <Typography variant="h6" sx={{ mb: 1 }}>
+        Infos Résa
+      </Typography>
+      <TextField
+        label="Téléphone"
+        value={phone}
+        onChange={handlePhoneChange}
+        placeholder="00 00 00 00 00"
+        inputProps={{ inputMode: 'numeric' }}
+        sx={{ mb: 1 }}
+      />{' '}
+      <TextField
+        label="Nom/prénom"
+        value={name}
+        onChange={e => setName(e.target.value)}
+        sx={{ mb: 1 }}
+      />{' '}
+      <FormControlLabel
+        control={<Checkbox checked={draps} onChange={e => setDraps(e.target.checked)} />}
+        label="Draps"
+        sx={{ mb: 1 }}
+      />
+      <TextField
+        multiline
+        rows={4}
+        fullWidth
+        value={info}
+        InputProps={{ readOnly: true }}
+        sx={{ mb: 1 }}
+      />
+      <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+        {airbnbUrl ? (
+          <Button
+            component="a"
+            href={airbnbUrl}
+            target="_blank"
+            rel="noopener"
+            variant="contained"
+            size="small"
+          >
+            Calendrier Airbnb
+          </Button>
+        ) : (
+          <Button
+            variant="contained"
+            size="small"
+            color={saveError ? 'error' : saving ? 'warning' : 'primary'}
+            onClick={handleSave}
+          >
+            {saving && <CircularProgress size={16} color="inherit" sx={{ mr: 1 }} />}
+            {saveError ? 'Erreur !' : 'Sauvegarder'}
+          </Button>
+        )}
+      </Box>
+      <Typography variant="h6" sx={{ mb: 1 }}>
+        SMS
+      </Typography>
+      <Box sx={{ border: '1px solid', borderColor: 'grey.400', borderRadius: 1, p: 2, mb: 1 }}>
+        <Typography sx={{ whiteSpace: 'pre-line' }}>{reservationText}</Typography>
+      </Box>
+      <Button
+        variant="contained"
+        size="small"
+        onClick={() => navigator.clipboard.writeText(reservationText)}
+        sx={{ mb: 2 }}
+      >
+        Copier
+      </Button>
+    </Box>
+  );
+}
+

--- a/frontend/src/components/Legend.js
+++ b/frontend/src/components/Legend.js
@@ -9,10 +9,9 @@ import {
   CircularProgress
 } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
-import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import { sourceColor, giteInitial } from '../utils';
 
-function Legend({ bookings, selectedUser, onUserChange, onRefresh, refreshing, onOpenAvailability }) {
+function Legend({ bookings, selectedUser, onUserChange, onRefresh, refreshing }) {
   const gites = Array.from(
     new Map(bookings.map(b => [b.giteId, b.giteNom])).entries()
   );
@@ -37,9 +36,6 @@ function Legend({ bookings, selectedUser, onUserChange, onRefresh, refreshing, o
           <MenuItem value="Seb">Seb</MenuItem>
         </Select>
         <Box>
-          <IconButton onClick={onOpenAvailability} sx={{ mr: 1 }}>
-            <CalendarMonthIcon />
-          </IconButton>
           <IconButton onClick={onRefresh} disabled={refreshing}>
             {refreshing ? <CircularProgress size={24} /> : <RefreshIcon />}
           </IconButton>


### PR DESCRIPTION
## Summary
- Replace popup flow with four horizontal panels and pink bottom navigation bar
- Integrate availability selection and reservation forms into second and third panels with gîte info subtitle
- Remove calendar button from legend

## Testing
- `npm test` *(fails: Missing script)*
- `CI=true npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68ab290d03248322b8f594af7081517f