### PR TITLE
Enable panel scrolling and mobile swipe

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Login from './components/Login';
 import CalendarBar from './components/CalendarBar';
 import ArrivalsList from './components/ArrivalsList';
@@ -36,6 +36,24 @@ function App() {
   );
   const [refreshing, setRefreshing] = useState(false);
   const [panel, setPanel] = useState(0);
+  const touchStartX = useRef(0);
+  const touchStartY = useRef(0);
+
+  const handleTouchStart = e => {
+    const t = e.touches[0];
+    touchStartX.current = t.clientX;
+    touchStartY.current = t.clientY;
+  };
+
+  const handleTouchEnd = e => {
+    const t = e.changedTouches[0];
+    const dx = t.clientX - touchStartX.current;
+    const dy = t.clientY - touchStartY.current;
+    if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) {
+      if (dx < 0 && panel < 3) setPanel(p => Math.min(p + 1, 3));
+      if (dx > 0 && panel > 0) setPanel(p => Math.max(p - 1, 0));
+    }
+  };
 
   // Chargement des données après authentification
   useEffect(() => {
@@ -83,9 +101,13 @@ function App() {
           sx={{
             display: 'flex',
             width: '400%',
+            height: '100%',
+            touchAction: 'pan-y',
             transform: `translateX(-${panel * 25}%)`,
             transition: 'transform 0.3s'
           }}
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
         >
           <Box sx={{ width: '100%', height: '100%', overflowY: 'auto', p: 2, pb: 7 }}>
             <CalendarBar bookings={data.reservations} errors={data.erreurs} />


### PR DESCRIPTION
## Summary
- Fix panels to fill viewport height and become scrollable
- Add touch gesture handlers for mobile swipe navigation

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `CI=true npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab3f3563f08322a15ecb988892a13d