### PR TITLE
Add price management

### DIFF
--- a/backend/prices.json
+++ b/backend/prices.json
@@ -1,0 +1,8 @@
+[
+  { "amount": 50, "gites": ["edmond"] },
+  { "amount": 55, "gites": ["edmond"] },
+  { "amount": 70, "gites": ["phonsine", "gree"] },
+  { "amount": 75, "gites": ["phonsine", "gree"] },
+  { "amount": 300, "gites": ["liberte"] },
+  { "amount": 350, "gites": ["liberte"] }
+]

--- a/frontend/src/components/AvailabilityPanels.js
+++ b/frontend/src/components/AvailabilityPanels.js
@@ -9,7 +9,8 @@ import {
   Popover,
   Checkbox,
   FormControlLabel,
-  CircularProgress
+  CircularProgress,
+  MenuItem
 } from '@mui/material';
 import { DateRange } from 'react-date-range';
 import 'react-date-range/dist/styles.css';
@@ -21,7 +22,8 @@ import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import {
   SAVE_RESERVATION,
   fetchSchoolHolidays,
-  fetchPublicHolidays
+  fetchPublicHolidays,
+  fetchPrices
 } from '../services/api';
 
 // Enable plugin
@@ -59,6 +61,8 @@ export function AvailabilityProvider({ bookings, children }) {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState(false);
   const [airbnbUrl, setAirbnbUrl] = useState(null);
+  const [prices, setPrices] = useState([]);
+  const [selectedPrice, setSelectedPrice] = useState('');
 
   useEffect(() => {
     const parts = [];
@@ -91,6 +95,21 @@ export function AvailabilityProvider({ bookings, children }) {
       })
       .catch(() => {});
   }, []);
+
+  useEffect(() => {
+    fetchPrices()
+      .then(data => setPrices(data))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (selectedGite) {
+      const opts = prices.filter(p => p.gites.includes(selectedGite.id));
+      setSelectedPrice(opts.length ? String(opts[0].amount) : 'other');
+    } else {
+      setSelectedPrice('');
+    }
+  }, [selectedGite, prices]);
 
   const handlePhoneChange = e => {
     const digits = e.target.value.replace(/\D/g, '').slice(0, 10);
@@ -136,6 +155,8 @@ export function AvailabilityProvider({ bookings, children }) {
         end: departure.format('DD/MM/YYYY'),
         summary: info.replace(/\n/g, ' ')
       };
+      const priceNum = selectedPrice && selectedPrice !== 'other' ? Number(selectedPrice) : null;
+      if (priceNum != null) payload.price = priceNum;
 
       try {
         const res = await fetch(SAVE_RESERVATION, {
@@ -191,13 +212,18 @@ export function AvailabilityProvider({ bookings, children }) {
       </div>
     );
   };
-
+  const nightCount = departure.diff(arrival, 'day');
+  const priceNum = selectedPrice && selectedPrice !== 'other' ? Number(selectedPrice) : null;
+  const priceLine =
+    priceNum != null
+      ? `\nLe tarif est de ${priceNum}€/nuit, soit ${priceNum * nightCount}€.`
+      : '';
   const reservationText = selectedGite
     ? `Bonjour,\nJe vous confirme votre réservation pour le gîte ${GITE_LABELS[selectedGite.id]} du ${arrival
         .locale('fr')
         .format('D MMMM YYYY')} à partir de 17h au ${departure
         .locale('fr')
-        .format('D MMMM YYYY')} midi.\nMerci Beaucoup,\nSoazig Molinier`
+        .format('D MMMM YYYY')} midi.${priceLine}\nMerci Beaucoup,\nSoazig Molinier`
     : '';
 
   return (
@@ -225,7 +251,10 @@ export function AvailabilityProvider({ bookings, children }) {
         saveError,
         airbnbUrl,
         reservationText,
-        renderDayContent
+        renderDayContent,
+        selectedPrice,
+        setSelectedPrice,
+        prices
       }}
     >
       {children}
@@ -370,7 +399,10 @@ export function AvailabilityReservationPanel() {
     saving,
     saveError,
     airbnbUrl,
-    reservationText
+    reservationText,
+    selectedPrice,
+    setSelectedPrice,
+    prices
   } = useContext(AvailabilityContext);
 
   const nightCount = departure.diff(arrival, 'day');
@@ -406,6 +438,24 @@ export function AvailabilityReservationPanel() {
         onChange={e => setName(e.target.value)}
         sx={{ mb: 1 }}
       />&nbsp;&nbsp;
+      <TextField
+        select
+        label="Prix/nuit"
+        value={selectedPrice}
+        onChange={e => setSelectedPrice(e.target.value)}
+        sx={{ mb: 1 }}
+      >
+        {selectedGite &&
+          prices
+            .filter(p => p.gites.includes(selectedGite.id))
+            .map(p => (
+              <MenuItem key={p.amount} value={String(p.amount)}>
+                {p.amount}€
+              </MenuItem>
+            ))}
+        <MenuItem value="other">autre</MenuItem>
+      </TextField>
+      &nbsp;&nbsp;
       <FormControlLabel
         control={<Checkbox checked={draps} onChange={e => setDraps(e.target.checked)} />}
         label="Draps"

--- a/frontend/src/components/AvailabilityPanels.js
+++ b/frontend/src/components/AvailabilityPanels.js
@@ -443,7 +443,7 @@ export function AvailabilityReservationPanel() {
         label="Prix/nuit"
         value={selectedPrice}
         onChange={e => setSelectedPrice(e.target.value)}
-        sx={{ mb: 1 }}
+        sx={{ mb: 1, minWidth: 120 }}
       >
         {selectedGite &&
           prices

--- a/frontend/src/components/SettingsPanel.js
+++ b/frontend/src/components/SettingsPanel.js
@@ -1,10 +1,104 @@
-import React from 'react';
-import { Box, Typography } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Typography,
+  TextField,
+  Button,
+  IconButton,
+  FormControl,
+  InputLabel,
+  Select,
+  OutlinedInput,
+  Chip,
+  MenuItem
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import { fetchPrices, savePrices } from '../services/api';
+
+const GITE_OPTIONS = ['phonsine', 'gree', 'edmond', 'liberte'];
 
 export default function SettingsPanel() {
+  const [prices, setPrices] = useState([]);
+
+  useEffect(() => {
+    fetchPrices()
+      .then(data => setPrices(data))
+      .catch(() => {});
+  }, []);
+
+  const handleAmountChange = (idx, value) => {
+    const next = [...prices];
+    next[idx].amount = Number(value);
+    setPrices(next);
+  };
+
+  const handleGitesChange = (idx, value) => {
+    const next = [...prices];
+    next[idx].gites = value;
+    setPrices(next);
+  };
+
+  const addPrice = () => {
+    setPrices([...prices, { amount: 0, gites: [] }]);
+  };
+
+  const removePrice = idx => {
+    setPrices(prices.filter((_, i) => i !== idx));
+  };
+
+  const handleSave = () => {
+    savePrices(prices).catch(() => {});
+  };
+
   return (
     <Box sx={{ p: 2 }}>
-      <Typography variant="h6">Réglages</Typography>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Réglages
+      </Typography>
+      {prices.map((p, idx) => (
+        <Box key={idx} sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+          <TextField
+            type="number"
+            label="Prix"
+            value={p.amount}
+            onChange={e => handleAmountChange(idx, e.target.value)}
+            sx={{ width: 100 }}
+          />
+          <FormControl sx={{ minWidth: 200 }}>
+            <InputLabel>Gîtes</InputLabel>
+            <Select
+              multiple
+              value={p.gites}
+              onChange={e => handleGitesChange(idx, e.target.value)}
+              input={<OutlinedInput label="Gîtes" />}
+              renderValue={selected => (
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                  {selected.map(value => (
+                    <Chip key={value} label={value} />
+                  ))}
+                </Box>
+              )}
+            >
+              {GITE_OPTIONS.map(g => (
+                <MenuItem key={g} value={g}>
+                  {g}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <IconButton onClick={() => removePrice(idx)}>
+            <DeleteIcon />
+          </IconButton>
+        </Box>
+      ))}
+      <Button startIcon={<AddIcon />} onClick={addPrice} sx={{ mr: 1 }}>
+        Ajouter
+      </Button>
+      <Button variant="contained" onClick={handleSave}>
+        Sauvegarder
+      </Button>
     </Box>
   );
 }
+

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -5,6 +5,7 @@ const ARRIVALS_URL = `${API_BASE}/api/arrivals`;
 const STATUS_URL = `${API_BASE}/api/statuses`;
 const REFRESH_URL = `${API_BASE}/api/reload-icals`;
 export const SAVE_RESERVATION = `${API_BASE}/api/save-reservation`;
+const PRICES_URL = `${API_BASE}/api/prices`;
 const HOLIDAYS_URL = `${API_BASE}/api/school-holidays`;
 const PUBLIC_HOLIDAYS_URL = 'https://calendrier.api.gouv.fr/jours-feries/metropole.json';
 
@@ -46,6 +47,22 @@ export async function fetchSchoolHolidays() {
 
 export async function fetchPublicHolidays() {
   const res = await fetch(PUBLIC_HOLIDAYS_URL);
+  if (!res.ok) throw new Error('HTTP ' + res.status);
+  return res.json();
+}
+
+export async function fetchPrices() {
+  const res = await fetch(PRICES_URL);
+  if (!res.ok) throw new Error('HTTP ' + res.status);
+  return res.json();
+}
+
+export async function savePrices(data) {
+  const res = await fetch(PRICES_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
   if (!res.ok) throw new Error('HTTP ' + res.status);
   return res.json();
 }


### PR DESCRIPTION
## Summary
- store nightly prices on the server and expose REST endpoints
- allow selecting and saving nightly price in reservation flow
- provide settings panel to edit price list

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=true npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab45f86d04832284ad1311303f4e93