### PR TITLE
Add navigation arrow and split reservation buttons

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -132,7 +132,7 @@ function App() {
             <AvailabilityPeriodPanel onReserve={() => setPanel(2)} />
           </Box>
           <Box sx={{ width: '100%', height: '100%', overflowY: 'auto', pb: 7 }}>
-            <AvailabilityReservationPanel />
+            <AvailabilityReservationPanel onBack={() => setPanel(1)} />
           </Box>
           <Box sx={{ width: '100%', height: '100%', overflowY: 'auto', pb: 7 }}>
             <SettingsPanel />

--- a/frontend/src/components/AvailabilityPanels.js
+++ b/frontend/src/components/AvailabilityPanels.js
@@ -10,7 +10,8 @@ import {
   Checkbox,
   FormControlLabel,
   CircularProgress,
-  MenuItem
+  MenuItem,
+  IconButton
 } from '@mui/material';
 import { DateRange } from 'react-date-range';
 import 'react-date-range/dist/styles.css';
@@ -19,6 +20,7 @@ import dayjs from 'dayjs';
 import 'dayjs/locale/fr';
 import useAvailability from '../hooks/useAvailability';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import {
   SAVE_RESERVATION,
   fetchSchoolHolidays,
@@ -136,6 +138,9 @@ export function AvailabilityProvider({ bookings, children }) {
 
   const handleReserve = (g, onGoto) => {
     setSelectedGite(g);
+    setAirbnbUrl(null);
+    setSaveError(false);
+    setSaving(false);
     if (onGoto) onGoto();
   };
 
@@ -382,7 +387,7 @@ export function AvailabilityPeriodPanel({ onReserve }) {
   );
 }
 
-export function AvailabilityReservationPanel() {
+export function AvailabilityReservationPanel({ onBack }) {
   const {
     arrival,
     departure,
@@ -409,9 +414,12 @@ export function AvailabilityReservationPanel() {
 
   return (
     <Box sx={{ p: 2 }}>
-      <Typography variant="h6" sx={{ mb: 1 }}>
-        Réservation
-      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+        <IconButton onClick={onBack} size="large">
+          <ArrowBackIcon fontSize="large" />
+        </IconButton>
+        <Typography variant="h6">Réservation</Typography>
+      </Box>
       {selectedGite && (
         <Typography
           variant="subtitle2"
@@ -470,28 +478,27 @@ export function AvailabilityReservationPanel() {
         sx={{ mb: 1 }}
       />
       <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
-        {airbnbUrl ? (
-          <Button
-            component="a"
-            href={airbnbUrl}
-            target="_blank"
-            rel="noopener"
-            variant="contained"
-            size="small"
-          >
-            Calendrier Airbnb
-          </Button>
-        ) : (
-          <Button
-            variant="contained"
-            size="small"
-            color={saveError ? 'error' : saving ? 'warning' : 'primary'}
-            onClick={handleSave}
-          >
-            {saving && <CircularProgress size={16} color="inherit" sx={{ mr: 1 }} />}
-            {saveError ? 'Erreur !' : 'Sauvegarder'}
-          </Button>
-        )}
+        <Button
+          variant="contained"
+          size="small"
+          color={saveError ? 'error' : saving ? 'warning' : 'primary'}
+          onClick={handleSave}
+        >
+          {saving && <CircularProgress size={16} color="inherit" sx={{ mr: 1 }} />}
+          {saveError ? 'Erreur !' : 'Sauvegarder'}
+        </Button>
+        <Button
+          variant="contained"
+          size="small"
+          component={airbnbUrl ? 'a' : 'button'}
+          href={airbnbUrl || undefined}
+          target={airbnbUrl ? '_blank' : undefined}
+          rel={airbnbUrl ? 'noopener' : undefined}
+          disabled={!airbnbUrl}
+          sx={{ bgcolor: '#000', color: '#fff', '&:hover': { bgcolor: '#333' } }}
+        >
+          Calendrier Airbnb
+        </Button>
       </Box>
       <Typography variant="h6" sx={{ mb: 1 }}>
         SMS


### PR DESCRIPTION
## Summary
- Add back arrow in reservation panel to return to date selection
- Separate saving and Airbnb calendar actions with dedicated buttons
- Reset reservation actions when selecting new period or gite

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=true npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab5125b6ec8322a94480448ba537da