### PR TITLE
Merge price and text storage and add data import/export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,5 +141,4 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 backend/statuses.json
-backend/prices.json
-backend/texts.json
+backend/data.json

--- a/backend/data-example.json
+++ b/backend/data-example.json
@@ -1,0 +1,9 @@
+{
+  "prices": [
+    { "amount": 100, "gites": ["phonsine", "gree"] },
+    { "amount": 120, "gites": ["edmond", "liberte"] }
+  ],
+  "texts": [
+    { "title": "Réservation", "text": "Pensez à réserver" }
+  ]
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -86,11 +86,8 @@ async function getSheetId(sheetName, token) {
 // Fichier de stockage des statuts
 const STATUS_FILE = path.join(__dirname, 'statuses.json');
 
-// Fichier de stockage des tarifs
-const PRICES_FILE = path.join(__dirname, 'prices.json');
-
-// Fichier de stockage des textes SMS
-const TEXTS_FILE = path.join(__dirname, 'texts.json');
+// Fichier de stockage des tarifs et textes
+const DATA_FILE = path.join(__dirname, 'data.json');
 
 function readStatuses() {
   if (!fs.existsSync(STATUS_FILE)) return {};
@@ -101,22 +98,33 @@ function writeStatuses(data) {
   fs.writeFileSync(STATUS_FILE, JSON.stringify(data, null, 2));
 }
 
-function readPrices() {
-  if (!fs.existsSync(PRICES_FILE)) return [];
-  return JSON.parse(fs.readFileSync(PRICES_FILE, 'utf-8'));
+function readData() {
+  if (!fs.existsSync(DATA_FILE)) return { prices: [], texts: [] };
+  return JSON.parse(fs.readFileSync(DATA_FILE, 'utf-8'));
 }
 
-function writePrices(data) {
-  fs.writeFileSync(PRICES_FILE, JSON.stringify(data, null, 2));
+function writeData(data) {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+function readPrices() {
+  return readData().prices || [];
+}
+
+function writePrices(prices) {
+  const data = readData();
+  data.prices = prices;
+  writeData(data);
 }
 
 function readTexts() {
-  if (!fs.existsSync(TEXTS_FILE)) return [];
-  return JSON.parse(fs.readFileSync(TEXTS_FILE, 'utf-8'));
+  return readData().texts || [];
 }
 
-function writeTexts(data) {
-  fs.writeFileSync(TEXTS_FILE, JSON.stringify(data, null, 2));
+function writeTexts(texts) {
+  const data = readData();
+  data.texts = texts;
+  writeData(data);
 }
 
 // --- School holidays cache ---
@@ -422,6 +430,16 @@ app.get('/api/texts', (req, res) => {
 
 app.post('/api/texts', (req, res) => {
   writeTexts(req.body || []);
+  res.json({ success: true });
+});
+
+// Import/export des données complètes
+app.get('/api/data', (req, res) => {
+  res.json(readData());
+});
+
+app.post('/api/data', (req, res) => {
+  writeData(req.body || { prices: [], texts: [] });
   res.json({ success: true });
 });
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -7,6 +7,7 @@ const REFRESH_URL = `${API_BASE}/api/reload-icals`;
 export const SAVE_RESERVATION = `${API_BASE}/api/save-reservation`;
 const PRICES_URL = `${API_BASE}/api/prices`;
 const TEXTS_URL = `${API_BASE}/api/texts`;
+const DATA_URL = `${API_BASE}/api/data`;
 const HOLIDAYS_URL = `${API_BASE}/api/school-holidays`;
 const PUBLIC_HOLIDAYS_URL = 'https://calendrier.api.gouv.fr/jours-feries/metropole.json';
 
@@ -76,6 +77,22 @@ export async function fetchTexts() {
 
 export async function saveTexts(data) {
   const res = await fetch(TEXTS_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) throw new Error('HTTP ' + res.status);
+  return res.json();
+}
+
+export async function fetchData() {
+  const res = await fetch(DATA_URL);
+  if (!res.ok) throw new Error('HTTP ' + res.status);
+  return res.json();
+}
+
+export async function saveData(data) {
+  const res = await fetch(DATA_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)


### PR DESCRIPTION
## Summary
- merge prices and texts into a single data.json file and expose combined `/api/data` endpoints
- add import/export controls in settings panel for backing up data
- update ignore rules and include data example

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `CI=true npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab707052e0832296478c08038ebc9c