### PR TITLE
Reduce mobile panel padding and add navigation indicator

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -109,7 +109,16 @@ function App() {
           onTouchStart={handleTouchStart}
           onTouchEnd={handleTouchEnd}
         >
-          <Box sx={{ width: '100%', height: '100%', overflowY: 'auto', p: 2, pb: 7 }}>
+          <Box
+            sx={{
+              width: '100%',
+              height: '100%',
+              overflowY: 'auto',
+              p: 2,
+              pl: { xs: 1, sm: 2 },
+              pb: 7
+            }}
+          >
             <CalendarBar bookings={data.reservations} errors={data.erreurs} />
             <Legend
               bookings={data.reservations}
@@ -146,22 +155,43 @@ function App() {
             width: '100%',
             bgcolor: '#f48fb1',
             display: 'flex',
-            justifyContent: 'space-around',
             py: 1
           }}
         >
-          <IconButton onClick={() => setPanel(0)} sx={{ color: '#fff' }}>
-            <AccessTimeIcon />
-          </IconButton>
-          <IconButton onClick={() => setPanel(1)} sx={{ color: '#fff' }}>
-            <CalendarMonthIcon />
-          </IconButton>
-          <IconButton onClick={() => setPanel(2)} sx={{ color: '#fff' }}>
-            <EditIcon />
-          </IconButton>
-          <IconButton onClick={() => setPanel(3)} sx={{ color: '#fff' }}>
-            <SettingsIcon />
-          </IconButton>
+          <Box
+            sx={{
+              position: 'absolute',
+              top: -6,
+              left: `calc((100% / 4) * ${panel} + (100% / 8))`,
+              transform: 'translateX(-50%)',
+              width: 16,
+              height: 16,
+              border: '2px solid #fff',
+              borderRadius: '50%',
+              transition: 'left 0.3s',
+              pointerEvents: 'none'
+            }}
+          />
+          <Box sx={{ flex: 1, textAlign: 'center' }}>
+            <IconButton onClick={() => setPanel(0)} sx={{ color: '#fff' }}>
+              <AccessTimeIcon />
+            </IconButton>
+          </Box>
+          <Box sx={{ flex: 1, textAlign: 'center' }}>
+            <IconButton onClick={() => setPanel(1)} sx={{ color: '#fff' }}>
+              <CalendarMonthIcon />
+            </IconButton>
+          </Box>
+          <Box sx={{ flex: 1, textAlign: 'center' }}>
+            <IconButton onClick={() => setPanel(2)} sx={{ color: '#fff' }}>
+              <EditIcon />
+            </IconButton>
+          </Box>
+          <Box sx={{ flex: 1, textAlign: 'center' }}>
+            <IconButton onClick={() => setPanel(3)} sx={{ color: '#fff' }}>
+              <SettingsIcon />
+            </IconButton>
+          </Box>
         </Box>
       </Box>
     </AvailabilityProvider>

--- a/frontend/src/components/ArrivalsList.js
+++ b/frontend/src/components/ArrivalsList.js
@@ -106,7 +106,7 @@ function ArrivalsList({ bookings, errors, statuses, onStatusChange }) {
   };
 
   return (
-    <Box sx={{ p: 2 }}>
+    <Box sx={{ p: 2, pl: { xs: 1, sm: 2 } }}>
       {['today', 'tomorrow'].map(key => (
         <Card key={key} sx={{ mb: 2, boxShadow: 3 }}>
           <CardContent>

--- a/frontend/src/components/AvailabilityPanels.js
+++ b/frontend/src/components/AvailabilityPanels.js
@@ -317,7 +317,7 @@ export function AvailabilityPeriodPanel({ onReserve }) {
   const nightCount = departure.diff(arrival, 'day');
 
   return (
-    <Box sx={{ p: 2 }}>
+    <Box sx={{ p: 2, pl: { xs: 1, sm: 2 } }}>
       <Typography variant="h6" sx={{ mb: 2 }}>
         Choisir des dates
       </Typography>
@@ -449,7 +449,7 @@ export function AvailabilityReservationPanel({ onBack }) {
   } = useContext(AvailabilityContext);
 
   return (
-    <Box sx={{ p: 2 }}>
+    <Box sx={{ p: 2, pl: { xs: 1, sm: 2 } }}>
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
         <IconButton onClick={onBack} size="large">
           <ArrowBackIcon fontSize="large" />

--- a/frontend/src/components/SettingsPanel.js
+++ b/frontend/src/components/SettingsPanel.js
@@ -125,7 +125,7 @@ export default function SettingsPanel() {
   };
 
   return (
-    <Box sx={{ p: 2 }}>
+    <Box sx={{ p: 2, pl: { xs: 1, sm: 2 } }}>
       <Typography variant="h4" sx={{ mb: 2 }}>
         Réglages
       </Typography>


### PR DESCRIPTION
## Summary
- Trim left padding on mobile across main panels for better fit
- Highlight active tab with animated white outline indicator in bottom navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=true npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac109721b4832292303fd315553575