### PR TITLE
Replace legend refresh button with pull-to-refresh spinner

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import {
 } from './services/api';
 import { Box, IconButton } from '@mui/material';
 import Legend from './components/Legend';
+import PullToRefresh from './components/PullToRefresh';
 import {
   AvailabilityProvider,
   AvailabilityPeriodPanel,
@@ -34,7 +35,6 @@ function App() {
   const [selectedUser, setSelectedUser] = useState(
     localStorage.getItem(USER_KEY) || 'Soaz'
   );
-  const [refreshing, setRefreshing] = useState(false);
   const [panel, setPanel] = useState(0);
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
@@ -85,10 +85,7 @@ function App() {
   };
 
   const handleRefresh = () => {
-    setRefreshing(true);
-    refreshCalendars()
-      .then(() => loadData())
-      .finally(() => setRefreshing(false));
+    return refreshCalendars().then(() => loadData());
   };
 
   if (!auth) return <Login onLogin={handleLogin} />;
@@ -109,7 +106,8 @@ function App() {
           onTouchStart={handleTouchStart}
           onTouchEnd={handleTouchEnd}
         >
-          <Box
+          <PullToRefresh
+            onRefresh={handleRefresh}
             sx={{
               width: '100%',
               height: '100%',
@@ -127,8 +125,6 @@ function App() {
                 setSelectedUser(user);
                 localStorage.setItem(USER_KEY, user);
               }}
-              onRefresh={handleRefresh}
-              refreshing={refreshing}
             />
             <ArrivalsList
               bookings={data.reservations}
@@ -136,16 +132,25 @@ function App() {
               statuses={statuses}
               onStatusChange={handleStatusChange}
             />
-          </Box>
-          <Box sx={{ width: '100%', height: '100%', overflowY: 'auto', pb: 7 }}>
+          </PullToRefresh>
+          <PullToRefresh
+            onRefresh={handleRefresh}
+            sx={{ width: '100%', height: '100%', overflowY: 'auto', pb: 7 }}
+          >
             <AvailabilityPeriodPanel onReserve={() => setPanel(2)} />
-          </Box>
-          <Box sx={{ width: '100%', height: '100%', overflowY: 'auto', pb: 7 }}>
+          </PullToRefresh>
+          <PullToRefresh
+            onRefresh={handleRefresh}
+            sx={{ width: '100%', height: '100%', overflowY: 'auto', pb: 7 }}
+          >
             <AvailabilityReservationPanel onBack={() => setPanel(1)} />
-          </Box>
-          <Box sx={{ width: '100%', height: '100%', overflowY: 'auto', pb: 7 }}>
+          </PullToRefresh>
+          <PullToRefresh
+            onRefresh={handleRefresh}
+            sx={{ width: '100%', height: '100%', overflowY: 'auto', pb: 7 }}
+          >
             <SettingsPanel />
-          </Box>
+          </PullToRefresh>
         </Box>
         <Box
           sx={{

--- a/frontend/src/components/Legend.jsx
+++ b/frontend/src/components/Legend.jsx
@@ -1,20 +1,8 @@
 import React from 'react';
-import {
-  Box,
-  Typography,
-  Avatar,
-  Select,
-  MenuItem,
-  IconButton,
-  CircularProgress
-} from '@mui/material';
-import RefreshIcon from '@mui/icons-material/Refresh';
-import { sourceColor, giteInitial } from '../utils';
+import { Box, Typography, Select, MenuItem } from '@mui/material';
+import { sourceColor } from '../utils';
 
-function Legend({ bookings, selectedUser, onUserChange, onRefresh, refreshing }) {
-  const gites = Array.from(
-    new Map(bookings.map(b => [b.giteId, b.giteNom])).entries()
-  );
+function Legend({ bookings, selectedUser, onUserChange }) {
   const sources = Array.from(new Set(bookings.map(b => b.source)));
 
   return (
@@ -35,38 +23,6 @@ function Legend({ bookings, selectedUser, onUserChange, onRefresh, refreshing })
           <MenuItem value="Soaz">Soaz</MenuItem>
           <MenuItem value="Seb">Seb</MenuItem>
         </Select>
-      <Box sx={{ mr: 5 }}>
-        <IconButton
-          onClick={onRefresh}
-          disabled={refreshing}
-          sx={{
-            size: 40, // taille de l'icône
-            bgcolor: "#f48fb1", // couleur de fond par défaut
-            color: "#fff", // couleur de l'icône
-            "&:hover": {
-              bgcolor: "#f46796ff" // couleur au survol
-            },
-            "&.Mui-disabled": {
-              bgcolor: "grey.100", // couleur quand désactivé
-              color: "grey.400"
-            }
-          }}
-        >
-          {refreshing ? <CircularProgress size={24} /> : <RefreshIcon />}
-        </IconButton>
-      </Box>
-
-      </Box>
-      <Box
-        sx={{
-          display: 'flex',
-          flexWrap: 'wrap',
-          justifyContent: 'center',
-          gap: 1,
-          mb: 0.5
-        }}
-      >
-
       </Box>
       <Box
         sx={{

--- a/frontend/src/components/PullToRefresh.jsx
+++ b/frontend/src/components/PullToRefresh.jsx
@@ -1,0 +1,63 @@
+import React, { useRef, useState } from 'react';
+import { Box, CircularProgress } from '@mui/material';
+
+const THRESHOLD = 60;
+
+function PullToRefresh({ onRefresh, children, sx = {} }) {
+  const ref = useRef(null);
+  const startY = useRef(0);
+  const [pull, setPull] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleTouchStart = e => {
+    if (ref.current.scrollTop === 0) {
+      startY.current = e.touches[0].clientY;
+    }
+  };
+
+  const handleTouchMove = e => {
+    if (ref.current.scrollTop === 0) {
+      const diff = e.touches[0].clientY - startY.current;
+      if (diff > 0) {
+        e.preventDefault();
+        setPull(diff);
+      }
+    }
+  };
+
+  const handleTouchEnd = () => {
+    if (pull > THRESHOLD) {
+      setRefreshing(true);
+      Promise.resolve(onRefresh()).finally(() => {
+        setRefreshing(false);
+        setPull(0);
+      });
+    } else {
+      setPull(0);
+    }
+  };
+
+  return (
+    <Box
+      ref={ref}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      sx={{ overflowY: 'auto', WebkitOverflowScrolling: 'touch', ...sx }}
+    >
+      <Box
+        sx={{
+          height: pull,
+          display: pull > 0 || refreshing ? 'flex' : 'none',
+          alignItems: 'center',
+          justifyContent: 'center'
+        }}
+      >
+        {refreshing && <CircularProgress size={24} sx={{ color: '#f48fb1' }} />}
+      </Box>
+      {children}
+    </Box>
+  );
+}
+
+export default PullToRefresh;


### PR DESCRIPTION
## Summary
- add custom pull-to-refresh component with pink spinner
- replace legend refresh button by global pull-to-refresh

## Testing
- `cd backend && npm test`
- `cd frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad79d0148083229e57a6aa550a07d5