### PR TITLE
Batch fetch arrival comments

### DIFF
--- a/frontend/src/components/ArrivalsList.jsx
+++ b/frontend/src/components/ArrivalsList.jsx
@@ -22,6 +22,7 @@ import {
   borderWidth,
   statusBorderColor
 } from '../utils';
+import { fetchComments } from '../services/api';
 
 /**
  * Liste des arrivées à venir (aujourd'hui + 6 jours).
@@ -35,20 +36,14 @@ function ArrivalsList({ bookings, errors, statuses, onStatusChange }) {
 
   React.useEffect(() => {
     const load = async () => {
-      const result = {};
-      for (const b of bookings) {
-        const key = `${b.giteId}_${b.debut}`;
-        const date = dayjs(b.debut).format('YYYY-MM-DD');
-        try {
-          console.log(`Fetching comment for ${b.giteId} on ${date}`);
-          const res = await fetch(`/api/comments/${b.giteId}/${date}`);
-          const data = await res.json();
-          result[key] = data.comment;
-        } catch {
-          result[key] = 'pas de commentaires';
-        }
+      const start = today.format('YYYY-MM-DD');
+      const end = today.add(6, 'day').format('YYYY-MM-DD');
+      try {
+        const data = await fetchComments(start, end);
+        setComments(data);
+      } catch {
+        setComments({});
       }
-      setComments(result);
     };
     if (bookings.length > 0) {
       load();

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -10,6 +10,7 @@ const TEXTS_URL = `${API_BASE}/api/texts`;
 const DATA_URL = `${API_BASE}/api/data`;
 const HOLIDAYS_URL = `${API_BASE}/api/school-holidays`;
 const PUBLIC_HOLIDAYS_URL = 'https://calendrier.api.gouv.fr/jours-feries/metropole.json';
+const COMMENTS_URL = `${API_BASE}/api/comments-range`;
 
 export async function fetchArrivals() {
   const res = await fetch(ARRIVALS_URL);
@@ -37,6 +38,12 @@ export async function updateStatus(id, done, user) {
 
 export async function refreshCalendars() {
   const res = await fetch(REFRESH_URL, { method: 'POST' });
+  if (!res.ok) throw new Error('HTTP ' + res.status);
+  return res.json();
+}
+
+export async function fetchComments(start, end) {
+  const res = await fetch(`${COMMENTS_URL}?start=${start}&end=${end}`);
   if (!res.ok) throw new Error('HTTP ' + res.status);
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add API endpoint to fetch comments for a date range
- request comments in one call via new fetchComments service
- update ArrivalsList to load comments once for upcoming week

## Testing
- `npm test`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aee6af153c8322844c206f0f75bfec