### PR TITLE
Add trash badges to legend

### DIFF
--- a/frontend/src/components/Legend.jsx
+++ b/frontend/src/components/Legend.jsx
@@ -1,9 +1,21 @@
 import React from 'react';
 import { Box, Typography, Select, MenuItem } from '@mui/material';
-import { sourceColor } from '../utils';
+import { sourceColor, TRASH_COLORS } from '../utils';
 
 function Legend({ bookings, selectedUser, onUserChange }) {
   const sources = Array.from(new Set(bookings.map(b => b.source)));
+
+  function getWeekNumber(date) {
+    const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+    const dayNum = d.getUTCDay() || 7;
+    d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    return Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+  }
+
+  const evenWeek = getWeekNumber(new Date()) % 2 === 0;
+  const mauronColor = evenWeek ? TRASH_COLORS.yellow : TRASH_COLORS.darkGreen;
+  const neantColor = evenWeek ? TRASH_COLORS.darkGreen : TRASH_COLORS.yellow;
 
   return (
     <Box sx={{ mb: 2, fontSize: 12 }}>
@@ -46,6 +58,41 @@ function Legend({ bookings, selectedUser, onUserChange }) {
             <Typography variant="caption">{type}</Typography>
           </Box>
         ))}
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          mt: 1,
+          gap: 0.5
+        }}
+      >
+        <Typography variant="caption">Poubelles</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Box
+            sx={{
+              width: 10,
+              height: 10,
+              bgcolor: neantColor,
+              borderRadius: '50%',
+              border: '1px solid rgba(0,0,0,0.3)'
+            }}
+          />
+          <Typography variant="caption">Néant</Typography>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Box
+            sx={{
+              width: 10,
+              height: 10,
+              bgcolor: mauronColor,
+              borderRadius: '50%',
+              border: '1px solid rgba(0,0,0,0.3)'
+            }}
+          />
+          <Typography variant="caption">Mauron</Typography>
+        </Box>
       </Box>
     </Box>
   );

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -14,6 +14,11 @@ export const COLORS = {
   }
 };
 
+export const TRASH_COLORS = {
+  yellow: 'yellow',
+  darkGreen: '#006400'
+};
+
 export const GITES = [
   { id: 'phonsine', name: 'Gîte de Phonsine' },
   { id: 'liberte', name: 'Gîte Le Liberté' },


### PR DESCRIPTION
## Summary
- show weekly trash badges "Néant" and "Mauron" with alternating colors
- move trash badge colors to reusable variables

## Testing
- `cd backend && npm test`
- `cd frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05fbb87548322be18251735ba307a