### PR TITLE
Add ok button to period picker

### DIFF
--- a/frontend/src/components/AvailabilityPanels.jsx
+++ b/frontend/src/components/AvailabilityPanels.jsx
@@ -372,13 +372,20 @@ export function AvailabilityPeriodPanel({ onReserve, onBack, panelBg }) {
           onClose={handleClosePicker}
           anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         >
-          <DateRange
-            ranges={[
-              { startDate: arrival.toDate(), endDate: departure.toDate(), key: 'selection' }
-            ]}
-            onChange={item => handleRangeChange(item.selection)}
-            dayContentRenderer={renderDayContent}
-          />
+          <Box sx={{ p: 1 }}>
+            <DateRange
+              ranges={[
+                { startDate: arrival.toDate(), endDate: departure.toDate(), key: 'selection' }
+              ]}
+              onChange={item => handleRangeChange(item.selection)}
+              dayContentRenderer={renderDayContent}
+            />
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
+              <Button variant="contained" size="small" onClick={handleClosePicker}>
+                ok
+              </Button>
+            </Box>
+          </Box>
         </Popover>
         <Chip label={`${nightCount} nuits`} size="small" sx={{ bgcolor: '#f48fb1', color: '#fff' }} />
       </Box>


### PR DESCRIPTION
## Summary
- add padding wrapper around the period picker popover content
- add an ok button under the calendar to close the popover

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d690e1fefc8322907137c283baf038