### PR TITLE
Make reservation information field editable

### DIFF
--- a/frontend/src/components/AvailabilityProvider.jsx
+++ b/frontend/src/components/AvailabilityProvider.jsx
@@ -49,6 +49,7 @@ export function AvailabilityProvider({ bookings, children }) {
   const [departure, setDeparture] = useState(dayjs().add(1, 'day'));
   const [selectedGite, setSelectedGite] = useState(null);
   const [info, setInfo] = useState('');
+  const [infoEdited, setInfoEdited] = useState(false);
   const [name, setName] = useState('');
   const [phone, setPhone] = useState('');
   const [singleBeds, setSingleBeds] = useState(0);
@@ -77,8 +78,11 @@ export function AvailabilityProvider({ bookings, children }) {
     if (childCount > 0) parts.push(`Enfants: ${childCount}`);
     if (includeBedding && singleBeds > 0) parts.push(`Lits simples: ${singleBeds}`);
     if (includeBedding && doubleBeds > 0) parts.push(`Lits doubles: ${doubleBeds}`);
-    setInfo(parts.join('\n'));
-  }, [name, phone, singleBeds, doubleBeds, adultCount, childCount, includeBedding]);
+    const generatedInfo = parts.join('\n');
+    if (!infoEdited) {
+      setInfo(generatedInfo);
+    }
+  }, [name, phone, singleBeds, doubleBeds, adultCount, childCount, includeBedding, infoEdited]);
 
   useEffect(() => {
     fetchSchoolHolidays()
@@ -137,6 +141,11 @@ export function AvailabilityProvider({ bookings, children }) {
     const digits = e.target.value.replace(/\D/g, '').slice(0, 10);
     const formatted = digits.replace(/(\d{2})(?=\d)/g, '$1 ').trim();
     setPhone(formatted);
+  };
+
+  const handleInfoChange = e => {
+    setInfo(e.target.value);
+    setInfoEdited(true);
   };
 
   const handleOpenPicker = event => {
@@ -301,6 +310,7 @@ export function AvailabilityProvider({ bookings, children }) {
         includeBedding,
         setIncludeBedding,
         info,
+        handleInfoChange,
         handlePhoneChange,
         handleSave,
         saving,

--- a/frontend/src/components/AvailabilityReservationPanel.jsx
+++ b/frontend/src/components/AvailabilityReservationPanel.jsx
@@ -42,6 +42,7 @@ export function AvailabilityReservationPanel({ onBack, panelBg }) {
     includeBedding,
     setIncludeBedding,
     info,
+    handleInfoChange,
     handlePhoneChange,
     handleSave,
     saving,
@@ -201,7 +202,7 @@ export function AvailabilityReservationPanel({ onBack, panelBg }) {
             rows={4}
             fullWidth
             value={info}
-            InputProps={{ readOnly: true }}
+            onChange={handleInfoChange}
             sx={{ mb: 1 }}
           />
           <Box sx={{ display: 'flex', gap: 1 }}>


### PR DESCRIPTION
## Summary
- allow manual editing of the Google/Airbnb reservation note field
- track manual edits to keep user-entered details from being overwritten by auto-generation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9dc91f808322abcecf99498d8a92)